### PR TITLE
Remove clj-statsd initialization from worker namespace

### DIFF
--- a/.github/workflows/test_lint.yml
+++ b/.github/workflows/test_lint.yml
@@ -1,10 +1,10 @@
-name: test-lint
+name: ci
 
 on: [ push ]
 
 jobs:
-  test-lint:
-    runs-on: ubuntu-latest
+  test:
+    runs-on: ubuntu-20.04
     container: clojure:openjdk-17-tools-deps-1.11.0.1100-bullseye
     services:
       redis:
@@ -31,11 +31,11 @@ jobs:
           GOOSE_TEST_RABBITMQ_PORT: 5672
           GOOSE_TEST_RABBITMQ_USERNAME: goose
           GOOSE_TEST_RABBITMQ_PASSWORD: top-gun
-      - name: Install clj-kondo
-        run: |
-          curl -sLO https://raw.githubusercontent.com/borkdude/clj-kondo/master/script/install-clj-kondo
-          chmod +x install-clj-kondo
-          ./install-clj-kondo
+  lint:
+    runs-on: ubuntu-20.04
+    container: cljkondo/clj-kondo:2022.10.05-alpine
+    steps:
+      - uses: actions/checkout@v3
       - name: Lint src
         run: clj-kondo --lint src/
       - name: Lint test

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.nilenso</groupId>
   <artifactId>goose</artifactId>
-  <version>0.3.0</version>
+  <version>0.3.1</version>
   <name>goose</name>
   <url>https://github.com/nilenso/goose</url>
 

--- a/src/goose/worker.clj
+++ b/src/goose/worker.clj
@@ -42,7 +42,7 @@
   {:threads               d/worker-threads
    :queue                 d/default-queue
    :graceful-shutdown-sec d/graceful-shutdown-sec
-   :metrics-plugin        (statsd/new statsd/default-opts)})
+   :metrics-plugin        (statsd/new {:enabled? false})})
 
 (defn start
   "Starts a worker process that does multiple things including, but not limited to:


### PR DESCRIPTION
- When `goose.worker` namespace is required, `default-opts` gets eval'd
- That would call `clj-statsd/setup` which starts an agent
- Since agents can only be closed by calling `(shutdown-agents)`, compilation gets stuck

Fixes #96