### PR TITLE
ci: update lint job

### DIFF
--- a/.github/workflows/test_lint.yml
+++ b/.github/workflows/test_lint.yml
@@ -1,10 +1,10 @@
-name: test-lint
+name: ci
 
 on: [ push ]
 
 jobs:
-  test-lint:
-    runs-on: ubuntu-latest
+  test:
+    runs-on: ubuntu-20.04
     container: clojure:openjdk-17-tools-deps-1.11.0.1100-bullseye
     services:
       redis:
@@ -31,11 +31,11 @@ jobs:
           GOOSE_TEST_RABBITMQ_PORT: 5672
           GOOSE_TEST_RABBITMQ_USERNAME: goose
           GOOSE_TEST_RABBITMQ_PASSWORD: top-gun
-      - name: Install clj-kondo
-        run: |
-          curl -sLO https://raw.githubusercontent.com/borkdude/clj-kondo/master/script/install-clj-kondo
-          chmod +x install-clj-kondo
-          ./install-clj-kondo
+  lint:
+    runs-on: ubuntu-20.04
+    container: cljkondo/clj-kondo:2022.10.05-alpine
+    steps:
+      - uses: actions/checkout@v3
       - name: Lint src
         run: clj-kondo --lint src/
       - name: Lint test


### PR DESCRIPTION
We use an image already having clojure tooling instead of installing them separately.

Extracted from #97 