### PR TITLE
Disable StatsD metrics by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 .cpcache/
 .idea/
 goose.iml
+.clj-kondo/
+.lsp/

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Getting Started
 #### Adding Goose as a dependency
 ```Clojure
 ;;; Clojure CLI/deps.edn
-com.nilenso/goose {:mvn/version "0.3.0"}
+com.nilenso/goose {:mvn/version "0.3.1"}
 
 ;;; Leiningen/Boot
-[com.nilenso/goose "0.3.0"]
+[com.nilenso/goose "0.3.1"]
 ```
 
 #### Client

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.nilenso</groupId>
   <artifactId>goose</artifactId>
-  <version>0.3.0</version>
+  <version>0.3.1</version>
   <name>goose</name>
   <url>https://github.com/nilenso/goose</url>
 

--- a/src/goose/metrics.clj
+++ b/src/goose/metrics.clj
@@ -2,8 +2,9 @@
   "Defines protocol for Metrics Backend.
   - [Monitoring & Alerting wiki](https://github.com/nilenso/goose/wiki/Monitoring-&-Alerting)"
   (:require
-    [goose.defaults :as d]
-    [goose.utils :as u]))
+   [goose.defaults :as d]
+   [goose.utils :as u]
+   [clojure.tools.logging :as log]))
 
 (defonce ^:no-doc jobs-processed "jobs.processed")
 (defonce ^:no-doc jobs-success "jobs.succeeded")
@@ -32,6 +33,14 @@
   (gauge [this key value tags] "Set gauge of given key")
   (increment [this key value tags] "Increment given key by value.")
   (timing [this key duration tags] "Record duration of given key."))
+
+;; nil behaves equivalent to a disabled metric.
+(extend-protocol Metrics
+  nil
+  (enabled? [_] false)
+  (gauge [_ _ _ _] (log/error "tried to gauge without a metrics plugin"))
+  (increment [_ _ _ _] (log/error "tried to increment without a metrics plugin"))
+  (timing [_ _ _ _] (log/error "tried to record duration without a metrics plugin")))
 
 (defn ^:no-doc increment-job-recovery-metric
   [metrics-plugin

--- a/src/goose/metrics.clj
+++ b/src/goose/metrics.clj
@@ -2,9 +2,10 @@
   "Defines protocol for Metrics Backend.
   - [Monitoring & Alerting wiki](https://github.com/nilenso/goose/wiki/Monitoring-&-Alerting)"
   (:require
-   [goose.defaults :as d]
-   [goose.utils :as u]
-   [clojure.tools.logging :as log]))
+    [goose.defaults :as d]
+    [goose.utils :as u]
+
+    [clojure.tools.logging :as log]))
 
 (defonce ^:no-doc jobs-processed "jobs.processed")
 (defonce ^:no-doc jobs-success "jobs.succeeded")
@@ -34,13 +35,13 @@
   (increment [this key value tags] "Increment given key by value.")
   (timing [this key duration tags] "Record duration of given key."))
 
-;; nil behaves equivalent to a disabled metric.
+;;; `nil` behaves equivalent to a disabled metric.
 (extend-protocol Metrics
   nil
   (enabled? [_] false)
-  (gauge [_ _ _ _] (log/error "tried to gauge without a metrics plugin"))
-  (increment [_ _ _ _] (log/error "tried to increment without a metrics plugin"))
-  (timing [_ _ _ _] (log/error "tried to record duration without a metrics plugin")))
+  (gauge [_ _ _ _] (log/error "Called `gauge` on nil metrics-plugin"))
+  (increment [_ _ _ _] (log/error "Called `increment` on nil metrics-plugin"))
+  (timing [_ _ _ _] (log/error "Called `timing` on nil metrics-plugin")))
 
 (defn ^:no-doc increment-job-recovery-metric
   [metrics-plugin

--- a/src/goose/specs.clj
+++ b/src/goose/specs.clj
@@ -164,10 +164,10 @@
   (s/keys :req-un [::broker
                    ::threads
                    ::queue
-                   ::graceful-shutdown-sec
-                   ::metrics-plugin]
+                   ::graceful-shutdown-sec]
           :opt-un [::middlewares
-                   ::error-service-config]))
+                   ::error-service-config
+                   ::metrics-plugin]))
 
 ;;; ============== FDEFs ==============
 (s/fdef c/perform-async

--- a/src/goose/worker.clj
+++ b/src/goose/worker.clj
@@ -38,7 +38,7 @@
   `:metrics-plugin`        : Publish Goose metrics to respective backend.\\
   Example                  : [[statsd/StatsD]]\\
   Given value must implement [[goose.metrics/Metrics]] protocol.
-  If set to `nil`, does not record metrics."
+  If unset or set to `nil`, does not record metrics."
   {:threads               d/worker-threads
    :queue                 d/default-queue
    :graceful-shutdown-sec d/graceful-shutdown-sec})

--- a/src/goose/worker.clj
+++ b/src/goose/worker.clj
@@ -2,7 +2,6 @@
   (:require
     [goose.broker :as b]
     [goose.defaults :as d]
-    [goose.metrics.statsd :as statsd]
     [goose.specs :as specs]))
 
 (defprotocol Shutdown
@@ -42,8 +41,7 @@
   If set to `nil`, does not record metrics."
   {:threads               d/worker-threads
    :queue                 d/default-queue
-   :graceful-shutdown-sec d/graceful-shutdown-sec
-   :metrics-plugin        (statsd/new statsd/default-opts)})
+   :graceful-shutdown-sec d/graceful-shutdown-sec})
 
 (defn start
   "Starts a worker process that does multiple things including, but not limited to:

--- a/src/goose/worker.clj
+++ b/src/goose/worker.clj
@@ -29,16 +29,17 @@
 
   `:graceful-shutdown-sec` : Waiting time for in-progress jobs to complete during shutdown.
 
-  `:metrics-plugin`        : Publish Goose metrics to respective backend.\\
-  Example                  : [[statsd/StatsD]]\\
-  Given value must implement [[goose.metrics/Metrics]] protocol.
-
   #### Optional Keys
   `:middlewares`          : Chain of function/s to run 'around' execution of a Job
   [Middlewares wiki](https://github.com/nilenso/goose/wiki/Middlewares)
 
   `:error-service-config` : Config for error service like Honeybadger, Sentry, etc.\\
-  [Error Handling & Retries wiki](https://github.com/nilenso/goose/wiki/Error-Handling-&-Retries)"
+  [Error Handling & Retries wiki](https://github.com/nilenso/goose/wiki/Error-Handling-&-Retries)
+
+  `:metrics-plugin`        : Publish Goose metrics to respective backend.\\
+  Example                  : [[statsd/StatsD]]\\
+  Given value must implement [[goose.metrics/Metrics]] protocol.
+  If set to `nil`, does not record metrics."
   {:threads               d/worker-threads
    :queue                 d/default-queue
    :graceful-shutdown-sec d/graceful-shutdown-sec

--- a/test/goose/worker_test.clj
+++ b/test/goose/worker_test.clj
@@ -1,0 +1,25 @@
+(ns goose.worker-test
+  (:require
+    [goose.client :as c]
+    [goose.test-utils :as tu]
+    [goose.worker :as w]
+
+    [clojure.test :refer [deftest is testing use-fixtures]]))
+
+;;; ======= Setup & Teardown ==========
+(use-fixtures :each tu/redis-fixture)
+
+;;; ======= TEST: nil metrics-plugin ==========
+(def nil-metrics-plugin-fn-executed (atom (promise)))
+(defn nil-metrics-plugin-fn [arg]
+  (deliver @nil-metrics-plugin-fn-executed arg))
+
+(deftest nil-metrics-plugin-test
+  (testing "Worker accepts a nil metrics-plugin"
+    (reset! nil-metrics-plugin-fn-executed (promise))
+    (let [arg "nil-metrics-plugin-test"
+          _ (c/perform-async tu/redis-client-opts `nil-metrics-plugin-fn arg)
+          worker-opts (dissoc tu/redis-worker-opts :metrics-plugin)
+          worker (w/start worker-opts)]
+      (is (= arg (deref @nil-metrics-plugin-fn-executed 100 :nil-metrics-plugin-test-timed-out)))
+      (w/stop worker))))


### PR DESCRIPTION
Fixes #96

Having a call to construct a statsD metric plugin in a top-level `def` causes the underlying clj-statsd library to spawn a thread pool for agents. This causes lein to get stuck when doing an AOT compilation to an uberjar, where all top-level defs are evaluated. We should avoid having side effects in our top-level defines anyway, and leave this option to the client.

We also extend the `Metric` protocol over nil—this will allow the metrics plugin to be set to `nil`, which will behave equivalent to a disabled metrics plugin.

This is useful for users trying out goose during development, or simply wanting to run it without a metrics plugin.

Supersedes #97 