### PR TITLE
tests: add docker-compose spec

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,19 +9,30 @@ Installation
 --------
 
 - [Clojure v1.11+](https://clojure.org/guides/install_clojure)
-- [Redis v6.2.0+](https://redis.io/docs/getting-started/installation/)
-- [RabbitMQ v3.9.0+](https://www.rabbitmq.com/download.html)
-  - [Management Plugin](https://www.rabbitmq.com/management.html#getting-started)
-  - [RabbitMQ Delayed Message Plugin](https://github.com/rabbitmq/rabbitmq-delayed-message-exchange)
+- Infra dependencies (note: for easy testing, use the docker compose manifest)
+  - [Redis v6.2.0+](https://redis.io/docs/getting-started/installation/)
+  - [RabbitMQ v3.9.0+](https://www.rabbitmq.com/download.html)
+    - [Management Plugin](https://www.rabbitmq.com/management.html#getting-started)
+    - [RabbitMQ Delayed Message Plugin](https://github.com/rabbitmq/rabbitmq-delayed-message-exchange)
 - Use `:repl` profile when starting REPL in your IDE
 
-Testing & Linting
+Testing
 --------
 
-- Install [clj-kondo](https://github.com/clj-kondo/clj-kondo/blob/master/doc/install.md#installation-script-macos-and-linux)
+The test suite is mostly integration tests, so use docker-compose to get the containerized Redis and RabbitMQ images for testing purposes.
+
 ```shell
+$ docker-compose up -d                   # Sets up infra required for tests.
 $ clj -X:test :nses '[goose.specs-test]' # Testing only 1 namespace.
 $ clj -X:test                            # Running all tests.
+$ docker-compose down                    # ...when you're done.
+```
+
+Linting
+--------
+- Install [clj-kondo](https://github.com/clj-kondo/clj-kondo/blob/master/doc/install.md#installation-script-macos-and-linux)
+
+```shell
 $ clj-kondo --lint src                   # Linting src dir.
 $ clj-kondo --lint test                  # Linting test dir.
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  redis:
+    image: redis:7.0
+    ports:
+      - 6379:6379
+  rabbitmq:
+    image: heidiks/rabbitmq-delayed-message-exchange:3.9.13-management
+    environment:
+      RABBITMQ_DEFAULT_USER: guest
+      RABBITMQ_DEFAULT_PASS: guest
+    ports:
+      - 5672:5672


### PR DESCRIPTION
Added a docker-compose file that will spin up all the infra needed for testing. Makes developing/one-off contributions on Goose much easier.