### PR TITLE
Fix find-by-pattern blocks indefinitely

### DIFF
--- a/src/goose/brokers/redis/commands.clj
+++ b/src/goose/brokers/redis/commands.clj
@@ -165,7 +165,7 @@
                   ;; We iterate from the end of the list down to index zero,
                   ;; since lists in Goose represent queues,
                   ;; and the front of a queue is the right side (the tail).
-                  (let [next-cursor (max 0 (dec cursor))
+                  (let [next-cursor (dec cursor)
                         elements (wcar* conn
                                    (car/lrange redis-key (dec cursor) (dec cursor)))]
                     [next-cursor elements]))]

--- a/src/goose/brokers/redis/commands.clj
+++ b/src/goose/brokers/redis/commands.clj
@@ -43,7 +43,7 @@
      (let [[next-cursor-string items] (scan-fn conn redis-key cursor)
            next-cursor (ensure-int next-cursor-string)]
        (concat items
-               (when-not (zero? next-cursor)
+               (when (pos? next-cursor)
                  (scan-seq conn scan-fn redis-key next-cursor)))))))
 
 (defn run-with-transaction

--- a/src/goose/brokers/redis/commands.clj
+++ b/src/goose/brokers/redis/commands.clj
@@ -165,7 +165,7 @@
                   ;; We iterate from the end of the list down to index zero,
                   ;; since lists in Goose represent queues,
                   ;; and the front of a queue is the right side (the tail).
-                  (let [next-cursor (dec cursor)
+                  (let [next-cursor (max 0 (dec cursor))
                         elements (wcar* conn
                                    (car/lrange redis-key (dec cursor) (dec cursor)))]
                     [next-cursor elements]))]

--- a/test/goose/test_utils.clj
+++ b/test/goose/test_utils.clj
@@ -98,3 +98,16 @@
   ;; If not shutdown, program won't quit.
   ;; https://stackoverflow.com/questions/38504056/program-wont-end-when-using-clj-statsd
   (shutdown-agents))
+
+;; ref: https://stackoverflow.com/questions/6694530/executing-a-function-with-a-timeout/27550676#answer-27550676
+(defn timeout
+  [timeout-ms callback]
+  (let [fut (future (callback))
+        ret (deref fut timeout-ms :timed-out)]
+    (when (= ret :timed-out)
+      (future-cancel fut))
+    ret))
+
+(defmacro with-timeout
+  [timeout-ms & body]
+  `(timeout ~timeout-ms (fn [] ~@body)))


### PR DESCRIPTION
When the queue is empty, the cursor will start decrementing from 0 and will never stop at 0.
Since `car/lrange` allows negative values, I leave it unchanged as it is.