### PR TITLE
Redis broker implementation for batching

### DIFF
--- a/src/goose/brokers/redis/batch.clj
+++ b/src/goose/brokers/redis/batch.clj
@@ -1,0 +1,25 @@
+(ns goose.brokers.redis.batch
+  (:require [goose.brokers.redis.commands :as redis-cmds]
+            [goose.defaults :as d]
+            [taoensso.carmine :as car]))
+
+(defn- set-batch-state
+  [{:keys [id jobs] :as batch}]
+  (let [batch-state-key (d/prefix-batch id)
+        batch-state (select-keys batch [:id :callback-fn-sym])
+        enqueued-job-set (d/construct-batch-job-set id d/enqueued-job-set)
+        job-ids (map :id jobs)]
+    (car/hmset* batch-state-key batch-state)
+    (apply car/sadd enqueued-job-set job-ids)))
+
+(defn- enqueue-jobs
+  [jobs]
+  (doseq [job jobs]
+    (car/lpush (:ready-queue job) job)))
+
+(defn enqueue
+  [redis-conn batch]
+  (redis-cmds/with-transaction redis-conn
+                               (car/multi)
+                               (set-batch-state batch)
+                               (enqueue-jobs (:jobs batch))))

--- a/src/goose/brokers/redis/broker.clj
+++ b/src/goose/brokers/redis/broker.clj
@@ -4,6 +4,7 @@
     [goose.brokers.redis.api.dead-jobs :as dead-jobs]
     [goose.brokers.redis.api.enqueued-jobs :as enqueued-jobs]
     [goose.brokers.redis.api.scheduled-jobs :as scheduled-jobs]
+    [goose.brokers.redis.batch :as batch]
     [goose.brokers.redis.commands :as redis-cmds]
     [goose.brokers.redis.connection :as redis-connection]
     [goose.brokers.redis.cron :as cron]
@@ -18,6 +19,10 @@
     [this job]
     (redis-cmds/enqueue-back (:redis-conn this) (:ready-queue job) job)
     (select-keys job [:id]))
+  (enqueue-batch
+    [this batch]
+    (batch/enqueue (:redis-conn this) batch)
+    (select-keys batch [:id]))
   (schedule [this schedule-epoch-ms job]
     (redis-scheduler/run-at (:redis-conn this) schedule-epoch-ms job))
   (register-cron [this cron-opts job-description]

--- a/src/goose/client.clj
+++ b/src/goose/client.clj
@@ -167,6 +167,7 @@
   (register-cron-schedule opts cron-opts execute-fn-sym args))
 
 (defn perform-batch
+  "Enqueues a batch of jobs for async execution."
   ([opts batch-opts execute-fn-sym args-coll]
    (let [jobs (map #(create-job opts execute-fn-sym %) args-coll)
          batch (batch/new batch-opts jobs)]

--- a/src/goose/defaults.clj
+++ b/src/goose/defaults.clj
@@ -11,12 +11,16 @@
 (def ^:no-doc in-progress-queue-prefix "goose/in-progress-jobs:")
 (def ^:no-doc process-prefix "goose/processes:")
 (def ^:no-doc heartbeat-prefix "goose/heartbeat:")
+(def ^:no-doc batch-prefix "goose/batch:")
 
 (def default-queue "default")
 (def schedule-queue "scheduled-jobs")
 (def dead-queue "dead-jobs")
 (def cron-queue "cron-schedules")
 (def cron-entries "cron-entries")
+(def enqueued-job-set "enqueued")
+(def successful-job-set "successful")
+(def dead-job-set "dead")
 
 (def protected-queues [schedule-queue dead-queue cron-queue cron-entries])
 
@@ -29,6 +33,14 @@
   (-> queue
       (str/split (re-pattern (str queue-prefix "*")))
       (second)))
+
+(defn ^:no-doc prefix-batch
+  [batch-id]
+  (str batch-prefix batch-id))
+
+(defn ^:no-doc construct-batch-job-set
+  [batch-id set]
+  (str batch-prefix batch-id "/" set))
 
 (def ^:no-doc prefixed-schedule-queue (prefix-queue schedule-queue))
 (def ^:no-doc prefixed-retry-schedule-queue (prefix-queue schedule-queue))


### PR DESCRIPTION
Implements `enqueue-batch` broker fn for Redis. 

The operation atomically creates,
1. Batch state
2. Adds jobs to the enqueued set
3. Enqueues jobs on the ready queue

Closes #116.

