### PR TITLE
Batching spec tests

### DIFF
--- a/src/goose/specs.clj
+++ b/src/goose/specs.clj
@@ -106,6 +106,12 @@
                    ::cron-schedule]
           :opt-un [::timezone]))
 
+;;; ============== Batch ==============
+(s/def ::callback-fn-sym (s/nilable ::fn-sym))
+(s/def ::batch-opts
+  (s/keys :opt-un [::callback-fn-sym]))
+(s/def ::batch-args (s/and sequential? #(every? sequential? %) (s/* ::args-serializable?)))
+
 ;;; ============== Retry Opts ==============
 (s/def ::max-retries nat-int?)
 (s/def ::retry-queue (s/nilable ::queue))
@@ -197,12 +203,19 @@
                      :args (s/* ::args-serializable?))
         :ret map?)
 
+(s/fdef c/perform-batch
+        :args (s/cat :opts ::client-opts
+                     :batch-opts ::batch-opts
+                     :execute-fn-sym ::fn-sym
+                     :args ::batch-args)
+        :ret map?)
 
 (def ^:private fns-with-specs
   [`c/perform-async
    `c/perform-at
    `c/perform-in-sec
-   `c/perform-every])
+   `c/perform-every
+   `c/perform-batch])
 
 (defn instrument
   "Instruments frequently-called functions.\\

--- a/test/goose/specs_test.clj
+++ b/test/goose/specs_test.clj
@@ -47,6 +47,15 @@
       #(c/perform-every tu/redis-client-opts (assoc cron-opts :cron-schedule "invalid") `tu/my-fn)
       #(c/perform-every tu/redis-client-opts (assoc cron-opts :timezone "invalid-zone-id") `tu/my-fn))
 
+    ; :batch-opts
+    (let [batch-opts {:callback-fn-sym `prn}]
+      #(c/perform-batch tu/redis-client-opts batch-opts `single-arity-fn [1 2])
+      #(c/perform-batch tu/redis-client-opts batch-opts `unresolvable-fn [["foo" "bar"]])
+      #(c/perform-batch tu/redis-client-opts batch-opts `single-arity-fn {1 2})
+      #(c/perform-batch tu/redis-client-opts
+                        (assoc batch-opts :callback-fn-sym `unresolvable-fn)
+                        `single-arity-fn [["foo" "bar"]]))
+
     ;; Common specs
     ;; :broker
     #(c/perform-async (assoc tu/redis-client-opts :broker :invalid) `tu/my-fn)


### PR DESCRIPTION
Add specs and spec tests to `perform-batch` client fn.

Is a part of #128 