### PR TITLE
feat: batch status API

### DIFF
--- a/src/goose/api/batch.clj
+++ b/src/goose/api/batch.clj
@@ -1,0 +1,21 @@
+(ns goose.api.batch
+  (:require [goose.batch :as batch]
+            [goose.broker :as b]
+            [goose.client]))
+
+(defn- into-batch-map
+  [batch]
+  (let [counts (select-keys batch [:enqueued :retrying :successful :dead])
+        total (->> (vals counts)
+                (reduce +))
+        status {:id         (get-in batch [:batch-state :id])
+                :created-at (get-in batch [:batch-state :created-at])
+                :status     (batch/status-from-counts counts total)
+                :total      total}]
+    (merge status counts)))
+
+(defn status
+  [broker id]
+  (let [batch (b/batch-status broker id)]
+    (when batch
+      (into-batch-map batch))))

--- a/src/goose/batch.clj
+++ b/src/goose/batch.clj
@@ -1,9 +1,22 @@
-(ns goose.batch)
+(ns goose.batch
+  (:require
+    [goose.utils :as u]))
+
+(def status-in-progress "in-progress")
+(def status-complete "complete")
 
 (defn new
   [{:keys [callback-fn-sym]} jobs]
   (let [id (str (random-uuid))]
     {:id              id
      :callback-fn-sym callback-fn-sym
-     :jobs            (map #(assoc % :batch-id id) jobs)}))
+     :jobs            (map #(assoc % :batch-id id) jobs)
+     :created-at      (u/epoch-time-ms)}))
+
+(defn status-from-counts
+  [{:keys [successful dead]}
+   total]
+  (cond
+    (= (+ successful dead) total) status-complete
+    :else status-in-progress))
 

--- a/src/goose/broker.clj
+++ b/src/goose/broker.clj
@@ -57,4 +57,7 @@
   (dead-jobs-replay-n-jobs [this n] "Re-enqueues n oldest Dead Jobs to front of queue for execution.")
   (dead-jobs-delete [this job] "Deletes given Dead Job.")
   (dead-jobs-delete-older-than [this epoch-ms] "Deletes Dead Jobs older than given epoch-ms.")
-  (dead-jobs-purge [this] "Purges all the Dead Jobs."))
+  (dead-jobs-purge [this] "Purges all the Dead Jobs.")
+
+  ;; batch API
+  (batch-status [this id] "Finds a Batch by `:id`"))

--- a/src/goose/brokers/redis/api/batch.clj
+++ b/src/goose/brokers/redis/api/batch.clj
@@ -1,0 +1,5 @@
+(ns goose.brokers.redis.api.batch
+  (:require [goose.brokers.redis.batch :as batch]))
+
+(defn status [redis-conn id]
+  (batch/get-batch-state redis-conn id))

--- a/src/goose/brokers/redis/batch.clj
+++ b/src/goose/brokers/redis/batch.clj
@@ -3,12 +3,13 @@
             [goose.defaults :as d]
             [goose.job :as job]
             [goose.retry]
+            [goose.utils :as u]
             [taoensso.carmine :as car]))
 
 (defn- set-batch-state
   [{:keys [id jobs] :as batch}]
   (let [batch-state-key (d/prefix-batch id)
-        batch-state (select-keys batch [:id :callback-fn-sym])
+        batch-state (select-keys batch [:id :callback-fn-sym :created-at])
         enqueued-job-set (d/construct-batch-job-set id d/enqueued-job-set)
         job-ids (map :id jobs)]
     (car/hmset* batch-state-key batch-state)
@@ -46,3 +47,26 @@
               (redis-cmds/move-between-sets redis-conn src dst id)
               (throw ex)))))
       (next opts job))))
+
+(defn get-batch-state
+  [redis-conn id]
+  (let [batch-state-key (d/prefix-batch id)
+        enqueued-job-set (d/construct-batch-job-set id d/enqueued-job-set)
+        retrying-job-set (d/construct-batch-job-set id d/retrying-job-set)
+        successful-job-set (d/construct-batch-job-set id d/successful-job-set)
+        dead-job-set (d/construct-batch-job-set id d/dead-job-set)
+        [_ [batch-state enqueued retrying successful dead]]
+        (car/atomic redis-conn
+                    redis-cmds/atomic-lock-attempts
+                    (car/multi)
+                    (car/hgetall batch-state-key)
+                    (car/scard enqueued-job-set)
+                    (car/scard retrying-job-set)
+                    (car/scard successful-job-set)
+                    (car/scard dead-job-set))]
+    (when (not-empty batch-state)
+      {:batch-state (u/flat-sequence->map batch-state)
+       :enqueued    enqueued
+       :retrying    retrying
+       :successful  successful
+       :dead        dead})))

--- a/src/goose/brokers/redis/broker.clj
+++ b/src/goose/brokers/redis/broker.clj
@@ -1,6 +1,7 @@
 (ns goose.brokers.redis.broker
   (:require
     [goose.broker :as b]
+    [goose.brokers.redis.api.batch :as batch-api]
     [goose.brokers.redis.api.dead-jobs :as dead-jobs]
     [goose.brokers.redis.api.enqueued-jobs :as enqueued-jobs]
     [goose.brokers.redis.api.scheduled-jobs :as scheduled-jobs]
@@ -88,7 +89,11 @@
   (dead-jobs-delete-older-than [this epoch-ms]
     (dead-jobs/delete-older-than (:redis-conn this) epoch-ms))
   (dead-jobs-purge [this]
-    (dead-jobs/purge (:redis-conn this))))
+    (dead-jobs/purge (:redis-conn this)))
+
+  ;; batch API
+  (batch-status [this id]
+    (batch-api/status (:redis-conn this) id)))
 
 (def default-opts
   "Map of sample config for Redis Message Broker.

--- a/src/goose/brokers/redis/commands.clj
+++ b/src/goose/brokers/redis/commands.clj
@@ -251,11 +251,9 @@
   (wcar* conn (car/zremrangebyscore sorted-set sorted-set-min score)))
 
 ;;; ============ Hashes ============
-
 (defn parse-map [conn hash]
   (wcar* conn (car/parse-map (car/hgetall hash) :keywordize)))
 
 ;;; ============ Misc ============
-
 (defn exists [conn key]
   (wcar* conn (car/exists key)))

--- a/src/goose/utils.clj
+++ b/src/goose/utils.clj
@@ -96,3 +96,8 @@
 
 (defmacro ^:no-doc with-retry [{:keys [count retry-delay-ms]} & body]
   `(with-retry* ~count ~retry-delay-ms (fn [] ~@body)))
+
+(defn ^:no-doc flat-sequence->map [coll]
+  (->>
+    (partition 2 coll)
+    (reduce (fn [map [k v]] (assoc map (keyword k) v)) {})))


### PR DESCRIPTION
The batch status API returns a map of metadata, count of jobs in different execution states. For example,
```clojure
{:id         "5e8f8198-dd82-48b1-a98f-2b366a71a106"
 :status     "in-progress"
 :total      26
 :enqueued   12
 :successful 6
 :retrying   5
 :dead       3
 :created-at "1691047307989"}
```

Changelist:
- Add `find-by-id` API for batch status
- API test
- Add `created-at` to batch state

Closes #119 