### PR TITLE
Fix docstring formatting & references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,3 +55,21 @@ These aren't exhaustive, but majorly inspired from [The Clojure Style Guide](htt
 - In specs, use `set` as a predicate for equality/contains functionality
 - Use compact metadata notation for flags
 - Follow [comments](https://guide.clojure.style/#comments) & [docstrings](https://guide.clojure.style/#documentation) guidelines
+
+Documentation Guidelines
+--------
+
+- Every new feature should have an ADR, well-formatted docstrings & a Wiki Page.
+- ADRs (Architecture Decision Records) should be added to [this folder](https://github.com/nilenso/goose/tree/main/architecture-decisions).
+- Docstrings serve 3 purposes:
+  1. Record the _How and What_ of an external function
+  1. Document usage of a function and meaning of its args
+  1. Beautify documentation of Goose APIs on [cljdoc](https://cljdoc.org/d/com.nilenso/goose/), a documentation website for Clojure community
+- When writing docstrings, follow these guidelines:
+  - Put code logic/reasoning in code-comments & only cover usage of a function in docstrings.
+  - Format docstrings in markdown for parsing by Cljdoc.
+  - Capitalize the first line.
+  - Use double backslashes (`\\`) for line break when a new line isn't feasible.
+  - Wrap positional args with backtick (example: `:broker`).
+  - Link to other functions/data in Goose using [API Wikilinks syntax](https://github.com/cljdoc/cljdoc/blob/master/doc/userguide/for-library-authors.adoc#use-api-wikilinks-from-docstrings) (example: `[[goose.retry/default-opts]]`).
+    - In API Wikilinks, use fully-qualified namespaces and avoid alias or relative paths for namespaces.

--- a/src/goose/brokers/redis/broker.clj
+++ b/src/goose/brokers/redis/broker.clj
@@ -92,7 +92,7 @@
   `:url`       : URL to connect to Redis.\\
   [URL Syntax wiki](https://github.com/lettuce-io/lettuce-core/wiki/Redis-URI-and-connection-details#uri-syntax)
 
-  `:pool-opts` : Config for connection-pooling.\\
+  `:pool-opts` : Config for connection-pooling. Refer to `goose.specs.redis/pool-opts` for allowed spec of pool opts.\\
   Example      : [[goose.defaults/redis-producer-pool-opts]]"
   {:url       d/redis-default-url
    :pool-opts nil})
@@ -124,7 +124,7 @@
   Example                           : [[default-opts]]
 
   `scheduler-polling-interval-sec`  : Interval at which to poll Redis for scheduled jobs.\\
-  Acceptable values                 : 1-60
+  Acceptable values                 : `1-60`
 
   ### Usage
   ```Clojure

--- a/src/goose/brokers/redis/broker.clj
+++ b/src/goose/brokers/redis/broker.clj
@@ -93,7 +93,7 @@
   [URL Syntax wiki](https://github.com/lettuce-io/lettuce-core/wiki/Redis-URI-and-connection-details#uri-syntax)
 
   `:pool-opts` : Config for connection-pooling.\\
-  Example      : [[d/redis-producer-pool-opts]], [[:goose.specs.redis/pool-opts]]"
+  Example      : [[goose.defaults/redis-producer-pool-opts]]"
   {:url       d/redis-default-url
    :pool-opts nil})
 

--- a/src/goose/brokers/rmq/broker.clj
+++ b/src/goose/brokers/rmq/broker.clj
@@ -76,14 +76,14 @@
   Example               : [[goose.brokers.rmq.queue/classic]], [[goose.brokers.rmq.queue/quorum]]
 
   `:publisher-confirms` : Strategy for RabbitMQ Publisher Confirms.\\
-  [Publisher Confirms wiki](https://www.rabbitmq.com/confirms.html#publisher-confirms)\\
-  [Publisher Confirms tutorial](https://www.rabbitmq.com/tutorials/tutorial-seven-java.html)
+  Wiki & Tutorial       : [Publisher Confirms wiki](https://www.rabbitmq.com/confirms.html#publisher-confirms), [Publisher Confirms tutorial](https://www.rabbitmq.com/tutorials/tutorial-seven-java.html)\\
+  Example               : [[goose.brokers.rmq.publisher-confirms/sync]], [[goose.brokers.rmq.publisher-confirms/async]]
 
   `:return-listener`    : Handle unroutable messages.\\
   Receives a map of keys `:reply-code` `:reply-text` `:exchange` `:routing-key` `:properties` `:body`.\\
   Example               : [[goose.brokers.rmq.return-listener/default]]
 
-  `:shutdown-listener`  : Handle abrupt RabbitMQ connection shutdowns not initialized by application.
+  `:shutdown-listener`  : Handle abrupt RabbitMQ connection shutdowns not initialized by application.\\
   Example               : [[goose.brokers.rmq.shutdown-listener/default]]"
   {:settings           {:uri d/rmq-default-url}
    :queue-type         rmq-queue/classic

--- a/src/goose/brokers/rmq/broker.clj
+++ b/src/goose/brokers/rmq/broker.clj
@@ -73,7 +73,7 @@
   [Connecting to RabbitMQ using Langohr](http://clojurerabbitmq.info/articles/connecting.html)
 
   `:queue-type`         : `classic` or `quorum` (for replication purpose).\\
-  Example               : [[rmq-queue/classic]], [[rmq-queue/quorum]]
+  Example               : [[goose.brokers.rmq.queue/classic]], [[goose.brokers.rmq.queue/quorum]]
 
   `:publisher-confirms` : Strategy for RabbitMQ Publisher Confirms.\\
   [Publisher Confirms wiki](https://www.rabbitmq.com/confirms.html#publisher-confirms)\\

--- a/src/goose/brokers/rmq/broker.clj
+++ b/src/goose/brokers/rmq/broker.clj
@@ -81,10 +81,10 @@
 
   `:return-listener`    : Handle unroutable messages.\\
   Receives a map of keys `:reply-code` `:reply-text` `:exchange` `:routing-key` `:properties` `:body`.\\
-  Example               : [[return-listener/default]]
+  Example               : [[goose.brokers.rmq.return-listener/default]]
 
   `:shutdown-listener`  : Handle abrupt RabbitMQ connection shutdowns not initialized by application.
-  Example               : [[shutdown-listener/default]]"
+  Example               : [[goose.brokers.rmq.shutdown-listener/default]]"
   {:settings           {:uri d/rmq-default-url}
    :queue-type         rmq-queue/classic
    :publisher-confirms publisher-confirms/sync

--- a/src/goose/brokers/rmq/queue.clj
+++ b/src/goose/brokers/rmq/queue.clj
@@ -25,7 +25,7 @@
      "x-quorum-initial-group-size" replication-factor}))
 
 (def ^:private declared-queues (atom #{}))
-(defn clear-cache [] (reset! declared-queues #{}))
+(defn ^:no-doc clear-cache [] (reset! declared-queues #{}))
 
 (defn ^:no-doc declare
   [ch {:keys [queue] :as queue-opts}]

--- a/src/goose/client.clj
+++ b/src/goose/client.clj
@@ -18,7 +18,7 @@
   [Message Broker wiki](https://github.com/nilenso/goose/wiki/Message-Brokers)
 
   `:queue`      : Destination where client produces to & worker consumes from.\\
-  Example       : [[d/default-queue]]
+  Example       : [[goose.defaults/default-queue]]
 
   `:retry-opts` : Configuration for handling Job failure.\\
   Example       : [[retry/default-opts]]\\

--- a/src/goose/client.clj
+++ b/src/goose/client.clj
@@ -21,7 +21,7 @@
   Example       : [[goose.defaults/default-queue]]
 
   `:retry-opts` : Configuration for handling Job failure.\\
-  Example       : [[retry/default-opts]]\\
+  Example       : [[goose.retry/default-opts]]\\
   [Error Handling & Retries wiki](https://github.com/nilenso/goose/wiki/Error-Handling-&-Retries)"
   {:queue      d/default-queue
    :retry-opts retry/default-opts})

--- a/src/goose/client.clj
+++ b/src/goose/client.clj
@@ -58,7 +58,7 @@
   Example          : [[default-opts]]
 
   `execute-fn-sym` : A fully-qualified function symbol called by worker.\\
-  Example          : ```my-fn`, ```ns-alias/my-fn`, `'fully-qualified-ns/my-fn`
+  Example          : `` `my-fn ``, `` `ns-alias/my-fn ``, `'fully-qualified-ns/my-fn`
 
   `args`           : Variadic values provided in given order when invoking `execute-fn-sym`.\\
    Given values must be serializable by `ptaoussanis/nippy`.
@@ -82,7 +82,7 @@
   `^Instant instant` : `java.time.Instant` at which job should be executed.
 
   `execute-fn-sym`   : A fully-qualified function symbol called by worker.\\
-  Example            : ```my-fn`, ```ns-alias/my-fn`, `'fully-qualified-ns/my-fn`
+  Example            : `` `my-fn ``, `` `ns-alias/my-fn ``, `'fully-qualified-ns/my-fn`
 
   `args`             : Variadic values provided in given order when invoking `execute-fn-sym`.\\
    Given values must be serializable by `ptaoussanis/nippy`.
@@ -107,7 +107,7 @@
   `sec`            : Delay of Job execution in seconds.
 
   `execute-fn-sym` : A fully-qualified function symbol called by worker.\\
-  Example          : ```my-fn`, ```ns-alias/my-fn`, `'fully-qualified-ns/my-fn`
+  Example          : `` `my-fn ``, `` `ns-alias/my-fn ``, `'fully-qualified-ns/my-fn`
 
   `args`           : Variadic values provided in given order when invoking `execute-fn-sym`.\\
    Given values must be serializable by `ptaoussanis/nippy`.
@@ -141,7 +141,7 @@
     - Defaults to system timezone
 
   `execute-fn-sym` : A fully-qualified function symbol called by worker.\\
-  Example          : ```my-fn`, ```ns-alias/my-fn`, `'fully-qualified-ns/my-fn`
+  Example          : `` `my-fn ``, `` `ns-alias/my-fn ``, `'fully-qualified-ns/my-fn`
 
   `args`           : Variadic values provided in given order when invoking `execute-fn-sym`.\\
    Given values must be serializable by `ptaoussanis/nippy`.

--- a/src/goose/utils.clj
+++ b/src/goose/utils.clj
@@ -9,10 +9,16 @@
     (java.net InetAddress)
     (java.time Instant)))
 
-(defn encode [x]
+(defn encode
+  "Serializes input to a byte array using `taoensso.nippy/freeze`.\\
+   To freeze custom types, extend the Clojure reader or use `taoensso.nippy/extend-freeze`."
+  [x]
   (nippy/freeze x))
 
-(defn decode [o]
+(defn decode
+  "Deserializes a frozen Nippy byte array to its original Clojure data type.\\
+   To thaw custom types, extend the Clojure reader or use `taoensso.nippy/extend-thaw`."
+  [o]
   (nippy/thaw o))
 
 (defmacro ^:no-doc log-on-exceptions


### PR DESCRIPTION
Cljdoc formatting was broken in 2 places:
1. The `execute-fn-sym` backtick formatting was broken [here](https://cljdoc.org/d/com.nilenso/goose/0.3.2/api/goose.client#keys)
2. [Cljdoc API Wikilinks](https://github.com/cljdoc/cljdoc/blob/master/doc/userguide/for-library-authors.adoc#use-api-wikilinks-from-docstrings) were broken in many places. Have referenced them using fully qualified namespace instead of an alias.
3. Updated CONTRIBUTING.md with guidelines on adding docstrings