### PR TITLE
Verify encoding inconsistencies post de/serialization of args

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -10,7 +10,8 @@
  :paths   ["src"]
 
  :aliases {:test       {:extra-paths ["test"]
-                        :extra-deps  {io.github.cognitect-labs/test-runner {:git/tag "v0.5.0" :git/sha "b3fd0d2"}}
+                        :extra-deps  {io.github.cognitect-labs/test-runner {:git/tag "v0.5.0" :git/sha "b3fd0d2"}
+                                      techascent/tech.ml.dataset {:mvn/version "7.000-beta-55"}}
                         :exec-fn     test-runner/test-and-shutdown}
            :repl       {:extra-deps {vvvvalvalval/scope-capture  {:mvn/version "0.3.2"}
                                      org.clojure/tools.namespace {:mvn/version "1.3.0"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,7 @@
 
  :aliases {:test       {:extra-paths ["test"]
                         :extra-deps  {io.github.cognitect-labs/test-runner {:git/tag "v0.5.0" :git/sha "b3fd0d2"}
-                                      techascent/tech.ml.dataset {:mvn/version "7.000-beta-55"}}
+                                      cnuernber/dtype-next                 {:mvn/version "10.102"}}
                         :exec-fn     test-runner/test-and-shutdown}
            :repl       {:extra-deps {vvvvalvalval/scope-capture  {:mvn/version "0.3.2"}
                                      org.clojure/tools.namespace {:mvn/version "1.3.0"}}}

--- a/src/goose/specs.clj
+++ b/src/goose/specs.clj
@@ -158,8 +158,9 @@
 
 ;;; ============== Client ==============
 (s/def ::args-serializable?
-  ;; Goose checks for consistency in encoding
-  ;; to determine serializability of given args.
+  ;; Serializability of args is determined by consistency in encoding.
+  ;; If this spec fails, serialize your custom data type as follows:
+  ;; https://github.com/nilenso/goose/wiki/Serializing-Custom-data-types
   #(try (let [encoding (u/encode %)
               re-encoding (u/encode (u/decode encoding))]
           (Arrays/equals ^"[B" encoding ^"[B" re-encoding))

--- a/src/goose/specs.clj
+++ b/src/goose/specs.clj
@@ -157,8 +157,13 @@
 
 ;;; ============== Client ==============
 (s/def ::args-serializable?
-  #(try (= % (u/decode (u/encode %)))
-        (catch Exception _ false)))
+  (s/and
+    #(try (= % (u/decode (u/encode %)))
+          (catch Exception _ false))
+
+    ;; Type check alongwith value equality check past encode/decode.
+    #(= (type %) (type (u/decode (u/encode %))))))
+
 (s/def ::instant #(instance? Instant %))
 (s/def ::client-opts (s/keys :req-un [::broker ::queue ::retry-opts]))
 

--- a/test/goose/specs_test.clj
+++ b/test/goose/specs_test.clj
@@ -10,7 +10,8 @@
     [goose.test-utils :as tu]
     [goose.worker :as w]
 
-    [clojure.test :refer [deftest is are]])
+    [clojure.test :refer [deftest is are]]
+    [tech.v3.dataset :as ds])
   (:import
     (clojure.lang ExceptionInfo)
     (java.time Instant)))
@@ -35,6 +36,10 @@
 
     ;; :args
     #(c/perform-async tu/redis-client-opts `tu/my-fn specs-test)
+    #(c/perform-async tu/redis-client-opts `tu/my-fn (-> {:1 1}
+                                                          ds/->dataset
+                                                          ds/mapseq-reader
+                                                          first))
 
     ;; :sec
     #(c/perform-in-sec tu/redis-client-opts 0.2 `tu/my-fn)

--- a/test/goose/specs_test.clj
+++ b/test/goose/specs_test.clj
@@ -8,30 +8,40 @@
     [goose.metrics.statsd :as statsd]
     [goose.specs :as specs]
     [goose.test-utils :as tu]
+    [goose.utils :as u]
     [goose.worker :as w]
 
-    [clojure.test :refer [deftest is are]]
-    [tech.v3.dataset :as ds])
+    [clojure.spec.alpha :as s]
+    [clojure.test :refer [deftest is are]])
   (:import
     (clojure.lang ExceptionInfo)
-    (java.time Instant)))
+    (java.time Instant)
+    (java.util HashMap)
+    (tech.v3.datatype FastStruct)))
 
 (defn single-arity-fn [_] "dummy")
 (def now (Instant/now))
 
-;;; A tech.v3.DS was reported to have mis-matching types post
-;;; de/serialization. This ugliness is the ONLY way to reproduce this bug.
-(def tech-v3-dataset-sample
-  (assoc (-> {:1 1 :2 2 :3 3 :4 4 :5 5 :6 6 :7 7 :8 8}
-             ds/->dataset
-             ds/mapseq-reader
-             first)
-    :9 9))
+(deftest args-encoding-consistency-test
+  ;; Not extending nippy serialization for custom data-types can lead to unexpected bugs.
+  ;; For instance, a de/serialized FastStruct object's value will be equal to original.
+  ;; However, the de/serialized object's type gets implicitly altered to PersistentHashMap.
+  ;; This type change leads to inconsistent encoding, leading to BUG #141.
+  ;; TODO: Reproduce value-equality & type-mismatch bug without dependency on a 3rd party library.
+  (let [;; Encoding inconsistency happens only when count of keys in FastStruct are greater than 8.
+        slots (HashMap. {:a 0 :b 1 :c 2 :d 3 :e 4 :f 5 :g 6 :h 7 :i 8})
+        vals [1 2 3 4 5 6 7 8 9]
+        arg (FastStruct. slots vals)]
+    ;; Test value-equality post de/serialization.
+    (is (= arg (u/decode (u/encode arg))))
+    ;; Expect encoding inconsistency post de/serialization.
+    (is (false? (s/valid? ::specs/args-serializable? arg)))))
 
 (deftest specs-test
   (specs/instrument)
   (are [sut]
     (is
+      ;; When specs are instrumented, expect exceptions for incorrect parameters.
       (thrown-with-msg?
         ExceptionInfo
         #"Call to goose.* did not conform to spec."
@@ -44,7 +54,7 @@
     #(c/perform-async tu/redis-client-opts `tu/redis-client-opts)
 
     ;; :args
-    #(c/perform-async tu/redis-client-opts `tu/my-fn tech-v3-dataset-sample)
+    #(c/perform-async tu/redis-client-opts `tu/my-fn specs-test)
 
     ;; :sec
     #(c/perform-in-sec tu/redis-client-opts 0.2 `tu/my-fn)

--- a/test/goose/specs_test.clj
+++ b/test/goose/specs_test.clj
@@ -19,6 +19,15 @@
 (defn single-arity-fn [_] "dummy")
 (def now (Instant/now))
 
+;;; A tech.v3.DS was reported to have mis-matching types post
+;;; de/serialization. This ugliness is the ONLY way to reproduce this bug.
+(def tech-v3-dataset-sample
+  (assoc (-> {:1 1 :2 2 :3 3 :4 4 :5 5 :6 6 :7 7 :8 8}
+             ds/->dataset
+             ds/mapseq-reader
+             first)
+    :9 9))
+
 (deftest specs-test
   (specs/instrument)
   (are [sut]
@@ -35,11 +44,7 @@
     #(c/perform-async tu/redis-client-opts `tu/redis-client-opts)
 
     ;; :args
-    #(c/perform-async tu/redis-client-opts `tu/my-fn specs-test)
-    #(c/perform-async tu/redis-client-opts `tu/my-fn (-> {:1 1}
-                                                          ds/->dataset
-                                                          ds/mapseq-reader
-                                                          first))
+    #(c/perform-async tu/redis-client-opts `tu/my-fn tech-v3-dataset-sample)
 
     ;; :sec
     #(c/perform-in-sec tu/redis-client-opts 0.2 `tu/my-fn)


### PR DESCRIPTION
## Bug-details
- Goose does de/serialization of Job args using Nippy. Validation of whether args are serializable is done by comparing value-equality of original args with de/serialized args. At the time of implementation, this seemed like an exhaustive way to detect serializability.
- For some data structures, value equality check post de/serialization returns true. However, re-encoding these data structures results in a **different** encoding. This happens when a _generic data-structure_, which should extend `freeeze/thaw` didn't do it, but got away with it due to equality of values post de/serialization.
- Post de-queuing a Job & executing it, Goose removes the Job by re-encoding it & calling `LREM <job-element>` (or equivalent command for other brokers).
- Due to encoding mismatch of args, the element in broker from the remove command.
- This causes a Job to stay enqueued inside a broker, and be executed indefinitely.
- This bug causes scheduled Jobs to be enqueued & executed infinitely as well.

## Reproducing the bug
```Clojure
;;; Import following dependency in deps:
;;; cnuernber/dtype-next {:mvn/version "10.102"}

(ns my.namespace
  (:require [goose.client :as c])
  (:import (tech.v3.datatype FastStruct)))

(def sample-dataset-data
  (let [;; Encoding inconsistency happens only when count of keys in FastStruct are greater than 8.
        slots {:a 0 :b 1 :c 2 :d 3 :e 4 :f 5 :g 6 :h 7 :i 8}
        vals [1 2 3 4 5 6 7 8 9]]
    (FastStruct. slots vals)))
(c/perform-async c/default-opts `prn sample-dataset-data)
```

## Solution
Goose will now check for consistency in encoding of given args. Maintaining pre-post serialization data integrity seems like a sufficient and exhaustive way to determine serializability, at least for now :)

## Changes Users will be required to make
When Goose spec catches inconsistent encodings, Users will have to extend Nippy serialization for their custom types. In this case, something like this:

```Clojure
(ns my.namespace
  (:require [taoensso.nippy :as nippy])
  (:import (tech.v3.datatype FastStruct)))

(nippy/extend-freeze
  tech.v3.datatype.FastStruct
  :tech.v3.datatype.FastStruct ; A unique identifier for nippy.
  [x data-out]
  (nippy/freeze-to-out! data-out (into {} x)))

(nippy/extend-thaw
  :tech.v3.datatype.FastStruct
  [data-input]
  (let [x (nippy/thaw-from-in! data-input)]
    (-> (FastStruct/createFactory (keys x))
        (.invoke (vec (vals x))))))

(comment
  (nippy/thaw (nippy/freeze sample-dataset-data)))
```