### PR TITLE
Build Redis API for console

### DIFF
--- a/src/goose/brokers/redis/api/enqueued_jobs.clj
+++ b/src/goose/brokers/redis/api/enqueued_jobs.clj
@@ -4,26 +4,34 @@
     [goose.defaults :as d]
     [goose.job :as job]))
 
-(defn list-all-queues [redis-conn]
+(defn list-all-queues
+  "Lists all the queues"
+  [redis-conn]
   (map d/affix-queue (redis-cmds/find-lists redis-conn (str d/queue-prefix "*"))))
 
-(defn size [redis-conn queue]
+(defn size
+  "Returns count of jobs in the queue"
+  [redis-conn queue]
   (redis-cmds/list-size redis-conn (d/prefix-queue queue)))
 
-(defn find-by-pattern [redis-conn queue match? limit]
+(defn find-by-pattern
+  "Finds job/s by user-defined parameters in given queue within the given limit"
+  [redis-conn queue match? limit]
   (redis-cmds/find-in-list redis-conn (d/prefix-queue queue) match? limit))
 
-(defn find-by-id [redis-conn queue id]
+(defn find-by-id
+  "Finds a job by `:id` in given queue"
+  [redis-conn queue id]
   (let [limit 1
         match? (fn [job] (= (:id job) id))]
     (first (find-by-pattern redis-conn queue match? limit))))
 
 (defn prioritise-execution
+  "Moves job/s to front of the queue after verification of existence"
   ([redis-conn {:keys [ready-queue] :as job}]
    (when (redis-cmds/list-position redis-conn ready-queue job)
      (redis-cmds/del-from-list-and-enqueue-front redis-conn ready-queue job)))
 
-  ;; This isn't exposed by Broker API and is used internally by console
   ([redis-conn queue jobs]
    (let [remove-jobs-with-invalid-positions-fn (fn [p j] (->> (mapv vector p j)
                                                               (remove #(nil? (first %)))
@@ -33,18 +41,21 @@
      (redis-cmds/del-from-list-and-enqueue-front-multiple redis-conn (d/prefix-queue queue) jobs))))
 
 (defn delete
+  "Delete job/s from its queue"
   ([redis-conn job]
    (let [queue (job/ready-or-retry-queue job)]
      (= 1 (redis-cmds/del-from-list redis-conn queue job))))
 
-  ;; Used internally by console
   ([redis-conn queue jobs]
    (not-any? #{0} (redis-cmds/del-from-list-multiple redis-conn (d/prefix-queue queue) jobs))))
 
-(defn purge [redis-conn queue]
+(defn purge
+  "Purges all the jobs in the queue"
+  [redis-conn queue]
   (let [ready-queue (d/prefix-queue queue)]
     (= 1 (redis-cmds/del-keys redis-conn ready-queue))))
 
-;;Used internally by console
-(defn get-by-range [redis-conn queue start stop]
+(defn get-by-range
+  "Get all the jobs from start of queue to stop (inclusive)"
+  [redis-conn queue start stop]
   (redis-cmds/range-from-front redis-conn (d/prefix-queue queue) start stop))

--- a/test/goose/brokers/redis/api_test.clj
+++ b/test/goose/brokers/redis/api_test.clj
@@ -4,8 +4,11 @@
     [goose.api.cron-jobs :as cron-jobs]
     [goose.api.dead-jobs :as dead-jobs]
     [goose.api.enqueued-jobs :as enqueued-jobs]
+    [goose.brokers.redis.api.enqueued-jobs :as redis-enqueued-jobs]
+    [goose.brokers.redis.commands :as redis-cmds]
     [goose.api.scheduled-jobs :as scheduled-jobs]
     [goose.batch]
+    [goose.defaults :as d]
     [goose.client :as c]
     [goose.test-utils :as tu]
     [goose.worker :as w]
@@ -45,6 +48,52 @@
     (let [job-id (str (random-uuid))]
       (is (nil? (tu/with-timeout default-timeout-ms
                                  (enqueued-jobs/find-by-id tu/redis-producer tu/queue job-id)))))))
+
+(deftest get-by-range-test
+  (let [[id1 id2 id3] (for [arg [1 2 3]]
+                        (:id (c/perform-async tu/redis-client-opts `tu/my-fn arg)))
+        [job1 job2 job3] (for [id [id1 id2 id3]]
+                           (enqueued-jobs/find-by-id tu/redis-producer tu/queue id))]
+    (testing "[redis] get jobs by range"
+      (is (= [job1 job2] (redis-enqueued-jobs/get-by-range tu/redis-conn tu/queue 0 1)))
+      (is (= [job1] (redis-enqueued-jobs/get-by-range tu/redis-conn tu/queue 0 0)))
+      (is (= [job1 job2 job3] (redis-enqueued-jobs/get-by-range tu/redis-conn tu/queue 0 2)))
+      (is (= [job1 job2 job3] (redis-enqueued-jobs/get-by-range tu/redis-conn tu/queue 0 10))))))
+
+(deftest enqueued-jobs-delete-multiple-test
+  (let [[id1 id2 id3 id4] (for [arg [1 2 3 4]]
+                            (:id (c/perform-async tu/redis-client-opts `tu/my-fn arg)))
+        [job1 job2 job3 job4] (for [id [id1 id2 id3 id4]]
+                                (enqueued-jobs/find-by-id tu/redis-producer tu/queue id))]
+    (testing "[redis] delete multiple enqueued-job"
+      (is (true? (redis-enqueued-jobs/delete tu/redis-conn tu/queue [job1 job2])))
+      (is (= 2 (enqueued-jobs/size tu/redis-producer tu/queue))))
+
+    (testing "[redis] delete single enqueued job from delete multiple jobs api"
+      (is (true? (redis-enqueued-jobs/delete tu/redis-conn tu/queue [job3])))
+      (is (= 1 (enqueued-jobs/size tu/redis-producer tu/queue))))
+
+    (testing "[redis] delete only valid enqueued job"
+      (is (false? (redis-enqueued-jobs/delete tu/redis-conn tu/queue [job4 {:job5 "invalid-job"}])))
+      (is (= 0 (enqueued-jobs/size tu/redis-producer tu/queue))))))
+
+(deftest enqueued-jobs-prioritise-multiple-test
+  (let [[id1 id2 id3] (for [arg [1 2 3]]
+                        (:id (c/perform-async tu/redis-client-opts `tu/my-fn arg)))
+        [job1 job2 job3] (for [id [id1 id2 id3]]
+                           (enqueued-jobs/find-by-id tu/redis-producer tu/queue id))]
+    (testing "[redis] prioritise single job using prioritise-execution's multiple endpoint"
+      (is (= [job1 job2 job3] (redis-cmds/range-from-front tu/redis-conn (d/prefix-queue tu/queue) 0 2)))
+      (redis-enqueued-jobs/prioritise-execution tu/redis-conn tu/queue [job2])
+      (is (= [job2 job1 job3] (redis-cmds/range-from-front tu/redis-conn (d/prefix-queue tu/queue) 0 2))))
+
+    (testing "[redis] prioritise multiple jobs"
+      (redis-enqueued-jobs/prioritise-execution tu/redis-conn tu/queue [job1 job3])
+      (is (= [job3 job1 job2] (redis-cmds/range-from-front tu/redis-conn (d/prefix-queue tu/queue) 0 2))))
+
+    (testing "[redis] prioritise only valid jobs"
+      (redis-enqueued-jobs/prioritise-execution tu/redis-conn tu/queue [{:job4 "invalid"} job2 {:job5 "invalid"}])
+      (is (= [job2 job3 job1] (redis-cmds/range-from-front tu/redis-conn (d/prefix-queue tu/queue) 0 2))))))
 
 (deftest scheduled-jobs-test
   (testing "[redis] scheduled-jobs API"

--- a/test/goose/brokers/redis/commands_test.clj
+++ b/test/goose/brokers/redis/commands_test.clj
@@ -66,6 +66,47 @@
       (is (= list-members
              (redis-cmds/list-seq tu/redis-conn "my-list"))))))
 
+(deftest list-position-multiple-test
+  (testing "iterating over a list from start to stop"
+    (let [list-members (map #(str "foo" %) (range 5))]
+      (doseq [member list-members]
+        (redis-cmds/enqueue-front tu/redis-conn "my-list" member))
+      (is (= [0] (redis-cmds/list-position-multiple tu/redis-conn "my-list" ["foo0"])))
+      (is (= [2 1] (redis-cmds/list-position-multiple tu/redis-conn "my-list" ["foo2" "foo1"]))))))
+
+(deftest range-from-front-test
+  (testing "should get the range from the front of the queue"
+    (doseq [member ["foo0" "foo1" "foo2" "foo3" "foo4"]]
+      (redis-cmds/enqueue-back tu/redis-conn "my-list" member))
+    (is (= ["foo0" "foo1" "foo2"] (redis-cmds/range-from-front tu/redis-conn "my-list" 0 2)))
+    (is (= ["foo0" "foo1" "foo2" "foo3" "foo4"] (redis-cmds/range-from-front tu/redis-conn "my-list" 0 4)))
+    (is (= ["foo0"] (redis-cmds/range-from-front tu/redis-conn "my-list" 0 0)))
+    (is (= ["foo2" "foo3"] (redis-cmds/range-from-front tu/redis-conn "my-list" 2 3)))
+    (is (= ["foo2" "foo3" "foo4"] (redis-cmds/range-from-front tu/redis-conn "my-list" 2 6)))))
+
+(deftest del-from-list-multiple-test
+  (testing "should delete multiple members from list"
+    (let [list-members (map #(str "foo" %) (range 5))]
+      (doseq [member list-members]
+        (redis-cmds/enqueue-back tu/redis-conn "my-list" member)))
+    (is (= [1 1 0] (redis-cmds/del-from-list-multiple tu/redis-conn "my-list" ["foo0" "foo1" "abc"])))
+    (is (= ["foo2" "foo3" "foo4"] (redis-cmds/range-from-front tu/redis-conn "my-list" 0 2)))
+
+    (is (= [1] (redis-cmds/del-from-list-multiple tu/redis-conn "my-list" ["foo3"])))
+    (is (= ["foo2" "foo4"] (redis-cmds/range-from-front tu/redis-conn "my-list" 0 1)))))
+
+(deftest del-from-list-and-enqueue-front-multiple-test
+  (testing "should prioritise execution of multiple jobs"
+    (let [list-members (map #(str "foo" %) (range 5))]
+      (doseq [member list-members]
+        (redis-cmds/enqueue-back tu/redis-conn "my-list" member)))
+    (is (= ["foo0" "foo1" "foo2" "foo3" "foo4"] (redis-cmds/range-from-front tu/redis-conn "my-list" 0 4)))
+    (redis-cmds/del-from-list-and-enqueue-front-multiple tu/redis-conn "my-list" ["foo2" "foo0"])
+    (is (= ["foo0" "foo2" "foo1" "foo3" "foo4"] (redis-cmds/range-from-front tu/redis-conn "my-list" 0 4)))
+
+    (redis-cmds/del-from-list-and-enqueue-front-multiple tu/redis-conn "my-list" ["foo3"])
+    (is (= ["foo3" "foo0" "foo2" "foo1" "foo4"] (redis-cmds/range-from-front tu/redis-conn "my-list" 0 4)))))
+
 (deftest find-in-list-test
   (testing "finding list members that match the given predicate"
     (let [foo-members (map #(str "foo" %) (range 1000))

--- a/test/goose/brokers/redis/commands_test.clj
+++ b/test/goose/brokers/redis/commands_test.clj
@@ -66,13 +66,13 @@
       (is (= list-members
              (redis-cmds/list-seq tu/redis-conn "my-list"))))))
 
-(deftest list-position-multiple-test
+(deftest list-position-test
   (testing "iterating over a list from start to stop"
     (let [list-members (map #(str "foo" %) (range 5))]
       (doseq [member list-members]
         (redis-cmds/enqueue-front tu/redis-conn "my-list" member))
-      (is (= [0] (redis-cmds/list-position-multiple tu/redis-conn "my-list" ["foo0"])))
-      (is (= [2 1] (redis-cmds/list-position-multiple tu/redis-conn "my-list" ["foo2" "foo1"]))))))
+      (is (= [0] (redis-cmds/list-position tu/redis-conn "my-list" "foo0")))
+      (is (= [2 1] (redis-cmds/list-position tu/redis-conn "my-list" "foo2" "foo1"))))))
 
 (deftest range-from-front-test
   (testing "should get the range from the front of the queue"
@@ -89,10 +89,10 @@
     (let [list-members (map #(str "foo" %) (range 5))]
       (doseq [member list-members]
         (redis-cmds/enqueue-back tu/redis-conn "my-list" member)))
-    (is (= [1 1 0] (redis-cmds/del-from-list-multiple tu/redis-conn "my-list" ["foo0" "foo1" "abc"])))
+    (is (= [1 1 0] (redis-cmds/del-from-list tu/redis-conn "my-list" "foo0" "foo1" "abc")))
     (is (= ["foo2" "foo3" "foo4"] (redis-cmds/range-from-front tu/redis-conn "my-list" 0 2)))
 
-    (is (= [1] (redis-cmds/del-from-list-multiple tu/redis-conn "my-list" ["foo3"])))
+    (is (= [1] (redis-cmds/del-from-list tu/redis-conn "my-list" "foo3")))
     (is (= ["foo2" "foo4"] (redis-cmds/range-from-front tu/redis-conn "my-list" 0 1)))))
 
 (deftest del-from-list-and-enqueue-front-multiple-test
@@ -101,10 +101,11 @@
       (doseq [member list-members]
         (redis-cmds/enqueue-back tu/redis-conn "my-list" member)))
     (is (= ["foo0" "foo1" "foo2" "foo3" "foo4"] (redis-cmds/range-from-front tu/redis-conn "my-list" 0 4)))
-    (redis-cmds/del-from-list-and-enqueue-front-multiple tu/redis-conn "my-list" ["foo2" "foo0"])
+    (is (= [[["OK" "QUEUED" "QUEUED"] [1 5]] [["OK" "QUEUED" "QUEUED"] [1 5]]]
+           (redis-cmds/del-from-list-and-enqueue-front tu/redis-conn "my-list" "foo2" "foo0")))
     (is (= ["foo0" "foo2" "foo1" "foo3" "foo4"] (redis-cmds/range-from-front tu/redis-conn "my-list" 0 4)))
 
-    (redis-cmds/del-from-list-and-enqueue-front-multiple tu/redis-conn "my-list" ["foo3"])
+    (is (= [[["OK" "QUEUED" "QUEUED"] [1 5]]](redis-cmds/del-from-list-and-enqueue-front tu/redis-conn "my-list" "foo3")))
     (is (= ["foo3" "foo0" "foo2" "foo1" "foo4"] (redis-cmds/range-from-front tu/redis-conn "my-list" 0 4)))))
 
 (deftest find-in-list-test


### PR DESCRIPTION
The changes are a part of #149. 
The PR includes backend API to enable the following things:
- Fetch n enqueued-jobs from the Redis for paginated view
- Delete multiple jobs
- Prioritise multiple jobs