### PR TITLE
Fix: Flaky tests

### DIFF
--- a/test/goose/factories.clj
+++ b/test/goose/factories.clj
@@ -27,7 +27,7 @@
     (:id j)))
 
 (defn schedule-job [& [overrides]]
-  (let [{:keys [scheduled-at] :as j} (job (merge {:scheduled-at (u/epoch-time-ms)} overrides))]
+  (let [{:keys [scheduled-at] :as j} (job (merge {:scheduled-at (+ (u/epoch-time-ms) 1000000)} overrides))]
     (scheduler/run-at tu/redis-conn scheduled-at j)
     (:id j)))
 


### PR DESCRIPTION
Problem: Sometimes, jobs move from `scheduled queue` to `enqueued queue` as the `scheduled-at` time surpass the current time while the tests run.

Example: [here](https://github.com/nilenso/goose/actions/runs/8060361531/job/22016261766)

Solution: Increase the `scheduled-at` in factories `schedule-job` to a higher value to avoid execution while tests are running.