### PR TITLE
Simplify route matching using bidi

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -8,7 +8,8 @@
            org.clojure/clojure       {:mvn/version "1.11.0"}
            org.clojure/tools.logging {:mvn/version "1.2.4"}
            ring/ring-core            {:mvn/version "1.11.0"}
-           hiccup/hiccup             {:mvn/version "2.0.0-RC2"}}
+           hiccup/hiccup             {:mvn/version "2.0.0-RC2"}
+           bidi/bidi                 {:mvn/version "2.1.6"}}
  :paths   ["src" "resources/public"]
 
  :aliases {:test       {:extra-paths ["test"]

--- a/src/goose/console.clj
+++ b/src/goose/console.clj
@@ -1,5 +1,10 @@
 (ns goose.console
-  (:require [goose.broker :as b]))
+  (:require [goose.broker :as b]
+            [ring.middleware.keyword-params :as ring-keyword-params]
+            [ring.middleware.params :as ring-params]))
+
 
 (defn app-handler [{:keys [broker] :as console-opts} req]
-  (b/handler broker (assoc req :console-opts console-opts)))
+  ((-> (partial b/handler broker)
+       ring-keyword-params/wrap-keyword-params
+       ring-params/wrap-params) (assoc req :console-opts console-opts)))

--- a/test/goose/brokers/redis/console_test.clj
+++ b/test/goose/brokers/redis/console_test.clj
@@ -24,14 +24,14 @@
 
 (deftest handler-test
   (testing "Should serve css file on GET request at /css/style.css route"
-    (let [response (redis-console/handler tu/redis-producer (-> (mock/request :get "/goose/console/css/style.css")
+    (let [response (redis-console/handler tu/redis-producer (-> (mock/request :get "goose/console/css/style.css")
                                                                 (assoc :console-opts {:broker       tu/redis-producer
                                                                                       :app-name     ""
-                                                                                      :route-prefix "goose/console/"})))]
+                                                                                      :route-prefix "goose/console"})))]
       (is (= (:status response) 200))
       (is (= (type (:body response)) File))
       (is (= (get-in response [:headers "Content-Type"]) "text/css"))))
-  (testing "Should serve goose logo on GET request at img/goose-logo.png route"
+  (testing "Should serve goose logo on GET request at /img/goose-logo.png route"
     (let [response (redis-console/handler tu/redis-producer (-> (mock/request :get "foo/img/goose-logo.png")
                                                                 (assoc :console-opts {:broker       tu/redis-producer
                                                                                       :app-name     ""
@@ -47,7 +47,7 @@
            {:status  302
             :headers {"Location" "foo/"}
             :body    ""})))
-  (testing "Should show not found page given invalid route"
+  (testing "Should show not-found page given invalid route"
     (is (= (redis-console/handler tu/redis-producer (-> (mock/request :get "foo/invalid")
                                                         (assoc :console-opts {:broker       tu/redis-producer
                                                                               :app-name     ""


### PR DESCRIPTION
With more routes(`/enqueued`, `/enqueued/queue/:queue`, `/enqueued/queue/:queue?page=3`) addition, the route matching was getting more complex.

To simplify this, a routing library was incorporated in Goose.
The design decision is captured in the [doc](https://nilenso.slack.com/archives/C03L1JGP3ME/p1709719867086529).