### PR TITLE
Console: Show enqueued jobs from queues 

### DIFF
--- a/resources/public/css/style.css
+++ b/resources/public/css/style.css
@@ -1,75 +1,298 @@
 body {
-    font-family: sans-serif, Arial;
-    margin: 0;
-    padding: 0;
-    background-color: #f4f4f4;
+  font-family: sans-serif, Arial;
+  margin: 0;
+  padding: 0;
+  background-color: #F2F4FD;
+  color: #585454;
 }
 
 header nav {
-    background-color: #ffffff;
-    display: flex;
-    justify-content: space-between;
-    padding: 1rem;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  background-color: #ffffff;
+  display: flex;
+  justify-content: space-between;
+  padding: 1rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
+
 main {
-    height: 50vh;
-    display: flex;
-    align-items: center;
+  height: 50vh;
+  display: flex;
+  align-items: center;
 }
 
 .nav-start {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-}
-a {
-    text-decoration: none;
-}
-#app-name {
-    font-size: 1.5rem;
-    color: #333;
-    margin-left: 15px;
-}
-.goose-logo a img{
-    margin-left: 15px;
-    height: 35px;
-    float: left;
-    overflow: auto;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
+a:hover {
+  color: #5881D8 !important;
+}
+
+a{
+  text-decoration: none;
+  color: #5881D8;
+}
+
+#menu .app-name {
+  font-size: 1.3rem;
+  color: #585454;
+  margin-left: 15px;
+}
+
+.goose-logo a img {
+  margin-left: 15px;
+  height: 35px;
+  float: left;
+  overflow: auto;
+}
 
 #menu a {
-    text-decoration: none;
-    color: #333;
-    margin-left: 2rem;
+  text-decoration: none;
+  color: #333;
+  margin-left: 1em;
+  font-size: 1em;
+}
+
+.disabled {
+  pointer-events: none;
+  color: #b2a9a9 !important;
+}
+
+.highlight {
+  color: #c8702A !important;
+  font-weight: bold;
 }
 
 .statistics {
-    display: flex;
-    justify-content: space-around;
-    align-items: center;
-    background: white;
-    margin: 2rem;
-    padding: 1rem;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    border-radius: 8px;
-    width: -webkit-fill-available;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  background: white;
+  margin: 2rem;
+  padding: 1rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  border-radius: 8px;
+  width: -webkit-fill-available;
 }
 
 .stat {
-    text-align: center;
-    display: grid;
+  text-align: center;
+  display: grid;
 }
 
 .stat .number {
-    color: #C87021; /* or any other color you prefer */
-    font-size: 36px;
-    font-weight: bold;
-    margin-bottom: 5px;
+  color: #C87021;
+  /* or any other color you prefer */
+  font-size: 36px;
+  font-weight: bold;
+  margin-bottom: 5px;
 }
 
 .stat .label {
-    color: #333;
-    font-size: 18px;
+  color: #333;
+  font-size: 18px;
+}
+
+/* Buttons */
+.btn {
+  padding: 7px 10px;
+  margin: 0 5px;
+  border-radius: 4px;
+  background-color: #5881D8;
+  color: #fff;
+  border: none;
+  font-weight: bold;
+  transition: box-shadow 0.3s ease;
+}
+
+.btn-sm {
+  padding: 5px 10px;
+  font-size: 12px;
+  line-height: 1.5;
+  border-radius: 3px
+}
+
+.btn-lg {
+  padding: 10px 16px;
+  font-size: 16px;
+  line-height: 1.3333;
+  border-radius: 6px;
+}
+
+.btn-action {
+  background-color: #fff;
+  color: #5881D8;
+  border: #5881D8 solid 1px;
+}
+
+.btn-danger {
+  background-color: #fff;
+  color: #DB460F;
+  border: #DB460F solid 1px;
+}
+
+button:active {
+  opacity: 0.8;
+}
+
+/* Redis Enqueued Page  */
+
+.redis-enqueued-main-content {
+  margin: 3em;
+}
+
+.redis-enqueued-main-content h1 {
+  color: #5881D8;
+}
+
+.redis-enqueued-main-content .content {
+  display: grid;
+  grid-template-columns: 20% 80%;
+
+}
+
+.redis-enqueued-main-content .selected {
+  color: #C87021;
+}
+
+.redis-enqueued-main-content .pagination a {
+  padding: 10px;
+}
+
+/* Sidebar */
+
+.redis-enqueued-main-content #sidebar {
+  padding-top: 30px;
+}
+
+.redis-enqueued-main-content .queue-list {
+  width: 170px;
+  box-sizing: border-box;
+  height: 60vh;
+  padding: auto;
+
+  overflow: auto;
+  scrollbar-width: thin;
+  scrollbar-color: #c4d0ec transparent;
+}
+
+.redis-enqueued-main-content .queue-list ul {
+  list-style: none;
+  padding: 0;
+}
+
+.redis-enqueued-main-content .queue-list ul a {
+  color: #5881D8;
+}
+
+.redis-enqueued-main-content .queue-list-item {
+  padding-bottom: 10px;
+  margin-bottom: 5px;
+}
+
+/* Right side sticky header and table content */
+
+.redis-enqueued-main-content .right-side {
+  padding-top: 30px;
+}
+
+.redis-enqueued-main-content .pagination {
+  justify-content: center;
+  display: flex;
+  margin: 10px;
+  height: 2em;
+}
+
+/* Sticky Header */
+
+.redis-enqueued-main-content .header {
+  background-color: #9FACC5;
+  height: 50px;
+  display: flex;
+}
+
+.redis-enqueued-main-content .header .filter-opts {
+  width: 80%;
+  margin: auto;
+  display: flex;
+}
+
+.redis-enqueued-main-content .header .filter-opts input,
+select {
+  padding: 6px 8px;
+  margin: 2px 0;
+  display: inline-block;
+  border: none;
+}
+
+.redis-enqueued-main-content .header .filter-opts-items {
+  margin: 0 10px;
+  display: flex;
+  justify-content: space-between;
+}
+
+.redis-enqueued-main-content .header .filter-opts-items .limit {
+  background-color: #fff;
+  font-size: small;
+  margin: auto;
+  padding: 7px 20px;
+}
+
+.redis-enqueued-main-content .header .action-buttons {
+  width: 20%;
+  margin: auto;
+  text-align: center;
+}
+
+/* Enqueued Jobs Table */
+
+
+.redis-enqueued-main-content .job-table {
+  width: 100%;
+  border-collapse: collapse;
+  text-align: justify;
+}
+
+.redis-enqueued-main-content .job-table th, td {
+  padding: 12px;
+  border: 1px solid #ddd;
+  white-space: nowrap;
+}
+
+.redis-enqueued-main-content .job-table th {
+  background-color: #fff;
+}
+
+.redis-enqueued-main-content .job-table th .id-h {
+  width: 40%;
+}
+
+.redis-enqueued-main-content .job-table .id {
+  color: #5881D8;
+}
+
+.redis-enqueued-main-content .job-table .execute-fn-symbol-h {
+  width: 10%;
+}
+
+.redis-enqueued-main-content .job-table .args-h {
+  width: 10%;
+}
+
+.redis-enqueued-main-content .job-table .enqueued-at-h {
+  width: 20%;
+}
+
+.redis-enqueued-main-content .job-table .select {
+  width: 20%;
+  text-align: center;
+}
+
+/* Bottom Purge Button  */
+.redis-enqueued-main-content .bottom {
+  margin-top: 50px;
+  justify-content: end;
+  display: flex;
 }

--- a/resources/public/css/style.css
+++ b/resources/public/css/style.css
@@ -35,6 +35,10 @@ a{
   color: #5881D8;
 }
 
+dialog {
+  border: none;
+}
+
 #menu .app-name {
   font-size: 1.3rem;
   color: #585454;
@@ -131,6 +135,11 @@ a{
   background-color: #fff;
   color: #DB460F;
   border: #DB460F solid 1px;
+}
+
+.btn-cancel {
+  color: #5881D8;
+  background-color: #d9d9d9;
 }
 
 button:active {
@@ -295,4 +304,14 @@ select {
   margin-top: 50px;
   justify-content: end;
   display: flex;
+}
+
+::backdrop {
+  opacity: 0.75;
+}
+
+.dialog-btns {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 20px;
 }

--- a/resources/public/js/index.js
+++ b/resources/public/js/index.js
@@ -1,0 +1,11 @@
+window.onload = () => {
+    const purge_dialog = document.querySelector(".purge-dialog");
+    const showDialog = document.querySelector(".purge-dialog-show")
+    const cancelDialog = document.querySelector("dialog .cancel")
+    showDialog.addEventListener("click", () => {
+        purge_dialog.showModal();
+    })
+    cancelDialog.addEventListener("click", () => {
+        purge_dialog.close();
+    })
+}

--- a/src/goose/brokers/redis/console.clj
+++ b/src/goose/brokers/redis/console.clj
@@ -30,11 +30,7 @@
          [:img {:src (prefix-route "/img/goose-logo.png") :alt "goose-logo"}]]]
        [:div#menu
         [:a {:href (prefix-route "") :class "app-name"} short-app-name]
-        [:a {:href (prefix-route "/enqueued")} "Enqueued"]
-        [:a {:href (prefix-route "/scheduled")} "Scheduled"]
-        [:a {:href (prefix-route "/periodic")} "Periodic"]
-        [:a {:href (prefix-route "/batch")} "Batch"]
-        [:a {:href (prefix-route "/dead")} "Dead"]]]]]))
+        [:a {:href (prefix-route "/enqueued")} "Enqueued"]]]]]))
 
 (defn- stats-bar [{:keys [prefix-route] :as page-data}]
   [:main

--- a/src/goose/brokers/redis/console.clj
+++ b/src/goose/brokers/redis/console.clj
@@ -183,7 +183,7 @@
                  [true not-found]]])
 
 (defn handler [_ {:keys                  [uri]
-                  {:keys [route-prefix]} :console-opts
+                  {:keys [route-prefix] :or {route-prefix ""}} :console-opts
                   :as                    req}]
   (let [{page-handler :handler
          route-params :route-params} (-> route-prefix

--- a/src/goose/brokers/redis/console.clj
+++ b/src/goose/brokers/redis/console.clj
@@ -5,8 +5,13 @@
             [goose.brokers.redis.api.enqueued-jobs :as enqueued-jobs]
             [goose.brokers.redis.api.scheduled-jobs :as scheduled-jobs]
             [goose.brokers.redis.cron :as periodic-jobs]
+            [goose.defaults :as d]
             [hiccup.page :refer [html5 include-css]]
-            [ring.util.response :as response]))
+            [hiccup.util :as hiccup-util]
+            [ring.util.response :as response])
+  (:import
+    (java.util Date)
+    (java.lang Math)))
 
 (defn- layout [& components]
   (fn [title {:keys [prefix-route] :as data}]
@@ -44,7 +49,7 @@
        [:a {:href (prefix-route route)}
         [:span.label label]]])]])
 
-(defn sidebar [{:keys [prefix-route queues queue]}]
+(defn- sidebar [{:keys [prefix-route queues queue]}]
   [:div#sidebar
    [:h3 "Queues"]
    [:div.queue-list
@@ -54,7 +59,7 @@
             :class (when (= q queue) "highlight")}
         [:li.queue-list-item q]])]]])
 
-(defn enqueued-jobs-table [jobs]
+(defn- enqueued-jobs-table [jobs]
   [:table.job-table
    [:thead
     [:tr
@@ -68,17 +73,43 @@
        [:td.id id]
        [:td.execute-fn-sym execute-fn-sym]
        [:td.args (string/join ", " args)]
-       [:td.enqueued-at (str (java.util.Date. enqueued-at))]])]])
+       [:td.enqueued-at (str (Date. enqueued-at))]])]])
 
-(defn enqueued-page-view [{:keys [jobs] :as data}]
+(defn pagination-stats [first-page curr-page last-page]
+  {:first-page first-page
+   :prev-page  (dec curr-page)
+   :curr-page  curr-page
+   :next-page  (inc curr-page)
+   :last-page  last-page})
+
+(defn- pagination [{:keys [prefix-route queue page total-jobs]}]
+  (let [{:keys [first-page prev-page curr-page
+                next-page last-page]} (pagination-stats (Integer/parseInt d/page) page
+                                                        (Math/ceilDiv total-jobs d/page-size))
+        page-uri (fn [p] (prefix-route "/enqueued/queue/" queue "?page=" p))
+        hyperlink (fn [page label visible? disabled? & class]
+                    (when visible?
+                      [:a {:class (conj class (when disabled? "disabled"))
+                           :href  (page-uri page)} label]))]
+    [:div
+     (hyperlink first-page (hiccup-util/escape-html "<<") ((comp not =) first-page curr-page last-page) (= curr-page first-page))
+     (hyperlink prev-page prev-page (> curr-page first-page) false)
+     (hyperlink curr-page curr-page ((comp not =) first-page curr-page last-page) true "highlight")
+     (hyperlink next-page next-page (< curr-page last-page) false)
+     (hyperlink last-page (hiccup-util/escape-html ">>") ((comp not =) first-page curr-page last-page) (= curr-page last-page))]))
+
+(defn- enqueued-page-view [{:keys [jobs total-jobs] :as data}]
   [:div.redis-enqueued-main-content
    [:h1 "Enqueued Jobs"]
    [:div.content
     (sidebar data)
     [:div.right-side
+     [:div.pagination
+      (pagination data)]
      (enqueued-jobs-table jobs)
-     [:div.bottom
-      [:button.btn.btn-danger.btn-md "Purge"]]]]])
+     (when (> total-jobs 0)
+       [:div.bottom
+        [:button.btn.btn-danger.btn-lg "Purge"]])]]])
 
 (defn jobs-size [redis-conn]
   (let [queues (enqueued-jobs/list-all-queues redis-conn)
@@ -92,14 +123,21 @@
      :periodic  periodic
      :dead      dead}))
 
-(defn enqueued-page-data [redis-conn queue]
-  (let [queues (enqueued-jobs/list-all-queues redis-conn)
+(defn enqueued-page-data
+  [redis-conn queue page]
+  (let [page (Integer/parseInt (or page d/page))
+        start (* (- page 1) d/page-size)
+        end (- (* page d/page-size) 1)
+
+        queues (enqueued-jobs/list-all-queues redis-conn)
         queue (or queue (first queues))
-        jobs (when queue
-               (enqueued-jobs/get-by-range redis-conn queue 0 10))]
-    {:queues queues
-     :jobs   jobs
-     :queue  queue}))
+        total-jobs (enqueued-jobs/size redis-conn queue)
+        jobs (enqueued-jobs/get-by-range redis-conn queue start end)]
+    {:queues     queues
+     :page       page
+     :queue      queue
+     :jobs       jobs
+     :total-jobs total-jobs}))
 
 
 (defn home-page [{:keys                     [prefix-route]
@@ -112,9 +150,10 @@
 
 (defn enqueued-page [{:keys                     [prefix-route]
                       {:keys [app-name broker]} :console-opts
+                      {:keys [page]}            :params
                       {:keys [queue]}           :route-params}]
   (let [view (layout header enqueued-page-view)
-        data (enqueued-page-data (:redis-conn broker) queue)]
+        data (enqueued-page-data (:redis-conn broker) queue page)]
     (response/response (view "Enqueued" (assoc data :app-name app-name
                                                     :prefix-route prefix-route)))))
 

--- a/src/goose/brokers/redis/console.clj
+++ b/src/goose/brokers/redis/console.clj
@@ -1,189 +1,8 @@
 (ns goose.brokers.redis.console
   (:require [bidi.bidi :as bidi]
-            [clojure.spec.alpha :as s]
-            [clojure.string :as string]
-            [goose.brokers.redis.api.dead-jobs :as dead-jobs]
-            [goose.brokers.redis.api.enqueued-jobs :as enqueued-jobs]
-            [goose.brokers.redis.api.scheduled-jobs :as scheduled-jobs]
-            [goose.brokers.redis.cron :as periodic-jobs]
-            [goose.defaults :as d]
-            [hiccup.page :refer [html5 include-css include-js]]
-            [hiccup.util :as hiccup-util]
-            [ring.util.response :as response])
-  (:import
-    (java.lang Math)
-    (java.util Date)))
-
-(s/def ::page (s/and pos-int?))
-(defn str->long
-  [str]
-  (if (= (type str) java.lang.Long)
-    str
-    (try (Long/parseLong str)
-         (catch Exception _ :clojure.spec.alpha/invalid))))
-
-(defn- layout [& components]
-  (fn [title {:keys [prefix-route] :as data}]
-    (html5 [:head
-            [:meta {:charset "UTF-8"}]
-            [:meta {:name "viewport" :content "width=device-width, initial-scale=1.0"}]
-            [:title title]
-            (include-css (prefix-route "/css/style.css"))
-            (include-js (prefix-route "/js/index.js"))]
-           [:body
-            (map (fn [c] (c data)) components)])))
-
-(defn- header [{:keys [app-name prefix-route] :or {app-name ""}}]
-  (let [short-app-name (if (> (count app-name) 20)
-                         (str (subs app-name 0 17) "..")
-                         app-name)]
-    [:header
-     [:nav
-      [:div.nav-start
-       [:div.goose-logo
-        [:a {:href ""}
-         [:img {:src (prefix-route "/img/goose-logo.png") :alt "goose-logo"}]]]
-       [:div#menu
-        [:a {:href (prefix-route "") :class "app-name"} short-app-name]
-        [:a {:href (prefix-route "/enqueued")} "Enqueued"]]]]]))
-
-(defn- stats-bar [{:keys [prefix-route] :as page-data}]
-  [:main
-   [:section.statistics
-    (for [{:keys [id label route]} [{:id :enqueued :label "Enqueued" :route "/enqueued"}
-                                    {:id :scheduled :label "Scheduled" :route "/scheduled"}
-                                    {:id :periodic :label "Periodic" :route "/periodic"}
-                                    {:id :dead :label "Dead" :route "/dead"}]]
-      [:div.stat {:id id}
-       [:span.number (str (get page-data id))]
-       [:a {:href (prefix-route route)}
-        [:span.label label]]])]])
-
-(defn- sidebar [{:keys [prefix-route queues queue]}]
-  [:div#sidebar
-   [:h3 "Queues"]
-   [:div.queue-list
-    [:ul
-     (for [q queues]
-       [:a {:href  (prefix-route "/enqueued/queue/" q)
-            :class (when (= q queue) "highlight")}
-        [:li.queue-list-item q]])]]])
-
-(defn- enqueued-jobs-table [jobs]
-  [:table.job-table
-   [:thead
-    [:tr
-     [:th.id-h "Id"]
-     [:th.execute-fn-sym-h "Execute fn symbol"]
-     [:th.args-h "Args"]
-     [:th.enqueued-at-h "Enqueued-at"]]]
-   [:tbody
-    (for [{:keys [id execute-fn-sym args enqueued-at]} jobs]
-      [:tr
-       [:td.id id]
-       [:td.execute-fn-sym execute-fn-sym]
-       [:td.args (string/join ", " args)]
-       [:td.enqueued-at (Date. ^Long enqueued-at)]])]])
-
-(defn pagination-stats [first-page curr-page last-page]
-  {:first-page first-page
-   :prev-page  (dec curr-page)
-   :curr-page  curr-page
-   :next-page  (inc curr-page)
-   :last-page  last-page})
-
-(defn- pagination [{:keys [prefix-route queue page total-jobs]}]
-  (let [{:keys [first-page prev-page curr-page
-                next-page last-page]} (pagination-stats d/page page
-                                                        (Math/ceilDiv total-jobs d/page-size))
-        page-uri (fn [p] (prefix-route "/enqueued/queue/" queue "?page=" p))
-        hyperlink (fn [page label visible? disabled? & class]
-                    (when visible?
-                      [:a {:class (conj class (when disabled? "disabled"))
-                           :href  (page-uri page)} label]))
-        single-page? (<= total-jobs d/page-size)]
-    [:div
-     (hyperlink first-page (hiccup-util/escape-html "<<") (not single-page?) (= curr-page first-page))
-     (hyperlink prev-page prev-page (> curr-page first-page) false)
-     (hyperlink curr-page curr-page (not single-page?) true "highlight")
-     (hyperlink next-page next-page (< curr-page last-page) false)
-     (hyperlink last-page (hiccup-util/escape-html ">>") (not single-page?) (= curr-page last-page))]))
-
-(defn confirmation-dialog [{:keys [prefix-route queue]}]
-  [:dialog {:class "purge-dialog"}
-   [:div "Are you sure, you want to purge the " [:span.highlight queue] " queue?"]
-   [:form {:action (prefix-route "/enqueued/queue/" queue)
-           :method "post"
-           :class  "dialog-btns"}
-    [:input {:name "_method" :type "hidden" :value "delete"}]
-    [:input {:name "queue" :value queue :type "hidden"}]
-    [:input {:type "button" :value "Cancel" :class "btn btn-md btn-cancel cancel"}]
-    [:input {:type "submit" :value "Confirm" :class "btn btn-danger btn-md"}]]])
-
-(defn- enqueued-page-view [{:keys [jobs total-jobs] :as data}]
-  [:div.redis-enqueued-main-content
-   [:h1 "Enqueued Jobs"]
-   [:div.content
-    (sidebar data)
-    [:div.right-side
-     [:div.pagination
-      (pagination data)]
-     (enqueued-jobs-table jobs)
-     (when (> total-jobs 0)
-       [:div.bottom
-        (confirmation-dialog data)
-        [:button {:class "btn btn-danger btn-lg purge-dialog-show"} "Purge"]])]]])
-
-(defn jobs-size [redis-conn]
-  (let [queues (enqueued-jobs/list-all-queues redis-conn)
-        enqueued (reduce (fn [total queue]
-                           (+ total (enqueued-jobs/size redis-conn queue))) 0 queues)
-        scheduled (scheduled-jobs/size redis-conn)
-        periodic (periodic-jobs/size redis-conn)
-        dead (dead-jobs/size redis-conn)]
-    {:enqueued  enqueued
-     :scheduled scheduled
-     :periodic  periodic
-     :dead      dead}))
-
-(defn enqueued-page-data
-  [redis-conn queue page]
-  (let [page (if (s/valid? ::page (str->long page))
-               (str->long page)
-               d/page)
-        start (* (- page 1) d/page-size)
-        end (- (* page d/page-size) 1)
-
-        queues (enqueued-jobs/list-all-queues redis-conn)
-        queue (or queue (first queues))
-        total-jobs (enqueued-jobs/size redis-conn queue)
-        jobs (enqueued-jobs/get-by-range redis-conn queue start end)]
-    {:queues     queues
-     :page       page
-     :queue      queue
-     :jobs       jobs
-     :total-jobs total-jobs}))
-
-(defn home-page [{:keys                     [prefix-route]
-                  {:keys [app-name broker]} :console-opts}]
-  (let [view (layout header stats-bar)
-        data (jobs-size (:redis-conn broker))]
-    (response/response (view "Home" (assoc data :app-name app-name
-                                                :prefix-route prefix-route)))))
-(defn purge-queue [{{:keys [broker]} :console-opts
-                    {:keys [queue]}  :params
-                    :keys            [prefix-route]}]
-  (enqueued-jobs/purge (:redis-conn broker) queue)
-  (response/redirect (prefix-route "/enqueued")))
-
-(defn enqueued-page [{:keys                     [prefix-route]
-                      {:keys [app-name broker]} :console-opts
-                      {:keys [page]}            :params
-                      {:keys [queue]}           :route-params}]
-  (let [view (layout header enqueued-page-view)
-        data (enqueued-page-data (:redis-conn broker) queue page)]
-    (response/response (view "Enqueued" (assoc data :app-name app-name
-                                                    :prefix-route prefix-route)))))
+            [goose.brokers.redis.console.pages.enqueued :as enqueued]
+            [goose.brokers.redis.console.pages.home :as home]
+            [ring.util.response :as response]))
 
 (defn- load-css [_]
   (-> "css/style.css"
@@ -208,10 +27,10 @@
 
 (defn routes [route-prefix]
   [route-prefix [["" redirect-to-home-page]
-                 ["/" home-page]
-                 ["/enqueued" {""                 enqueued-page
-                               ["/queue/" :queue] [[:get enqueued-page]
-                                                   [:delete purge-queue]]}]
+                 ["/" home/page]
+                 ["/enqueued" {""                 enqueued/page
+                               ["/queue/" :queue] [[:get enqueued/page]
+                                                   [:delete enqueued/purge-queue]]}]
                  ["/css/style.css" load-css]
                  ["/img/goose-logo.png" load-img]
                  ["/js/index.js" load-js]
@@ -223,7 +42,10 @@
   (let [{page-handler :handler
          route-params :route-params} (-> route-prefix
                                          routes
-                                         (bidi/match-route uri {:request-method request-method}))]
+                                         (bidi/match-route
+                                           uri
+                                           {:request-method
+                                            request-method}))]
     (-> req
         (assoc :route-params route-params)
         page-handler)))

--- a/src/goose/brokers/redis/console/data.clj
+++ b/src/goose/brokers/redis/console/data.clj
@@ -1,0 +1,38 @@
+(ns goose.brokers.redis.console.data
+  (:require [clojure.spec.alpha :as s]
+            [goose.brokers.redis.api.dead-jobs :as dead-jobs]
+            [goose.brokers.redis.api.enqueued-jobs :as enqueued-jobs]
+            [goose.brokers.redis.api.scheduled-jobs :as scheduled-jobs]
+            [goose.brokers.redis.cron :as periodic-jobs]
+            [goose.defaults :as d]
+            [goose.brokers.redis.console.specs :as specs]))
+
+(defn jobs-size [redis-conn]
+  (let [queues (enqueued-jobs/list-all-queues redis-conn)
+        enqueued (reduce (fn [total queue]
+                           (+ total (enqueued-jobs/size redis-conn queue))) 0 queues)
+        scheduled (scheduled-jobs/size redis-conn)
+        periodic (periodic-jobs/size redis-conn)
+        dead (dead-jobs/size redis-conn)]
+    {:enqueued  enqueued
+     :scheduled scheduled
+     :periodic  periodic
+     :dead      dead}))
+
+(defn enqueued-page-data
+  [redis-conn queue page]
+  (let [page (if (s/valid? ::specs/page (specs/str->long page))
+               (specs/str->long page)
+               d/page)
+        start (* (- page 1) d/page-size)
+        end (- (* page d/page-size) 1)
+
+        queues (enqueued-jobs/list-all-queues redis-conn)
+        queue (or queue (first queues))
+        total-jobs (enqueued-jobs/size redis-conn queue)
+        jobs (enqueued-jobs/get-by-range redis-conn queue start end)]
+    {:queues     queues
+     :page       page
+     :queue      queue
+     :jobs       jobs
+     :total-jobs total-jobs}))

--- a/src/goose/brokers/redis/console/pages/components.clj
+++ b/src/goose/brokers/redis/console/pages/components.clj
@@ -1,0 +1,28 @@
+(ns goose.brokers.redis.console.pages.components
+  (:require [hiccup.page :refer [html5 include-css include-js]]))
+
+(defn layout [& components]
+  (fn [title {:keys [prefix-route] :as data}]
+    (html5 {:lang "en"}
+           [:head
+            [:meta {:charset "UTF-8"}]
+            [:meta {:name "viewport" :content "width=device-width, initial-scale=1.0"}]
+            [:title title]
+            (include-css (prefix-route "/css/style.css"))
+            (include-js (prefix-route "/js/index.js"))]
+           [:body
+            (map (fn [c] (c data)) components)])))
+
+(defn header [{:keys [app-name prefix-route] :or {app-name ""}}]
+  (let [short-app-name (if (> (count app-name) 20)
+                         (str (subs app-name 0 17) "..")
+                         app-name)]
+    [:header
+     [:nav
+      [:div.nav-start
+       [:div.goose-logo
+        [:a {:href ""}
+         [:img {:src (prefix-route "/img/goose-logo.png") :alt "goose-logo"}]]]
+       [:div#menu
+        [:a {:href (prefix-route "") :class "app-name"} short-app-name]
+        [:a {:href (prefix-route "/enqueued")} "Enqueued"]]]]]))

--- a/src/goose/brokers/redis/console/pages/enqueued.clj
+++ b/src/goose/brokers/redis/console/pages/enqueued.clj
@@ -1,0 +1,101 @@
+(ns goose.brokers.redis.console.pages.enqueued
+  (:require [clojure.string :as string]
+            [goose.brokers.redis.api.enqueued-jobs :as enqueued-jobs]
+            [goose.brokers.redis.console.data :as data]
+            [goose.brokers.redis.console.pages.components :as c]
+            [goose.defaults :as d]
+            [hiccup.util :as hiccup-util]
+            [ring.util.response :as response])
+  (:import
+    (java.lang Math)
+    (java.util Date)))
+
+(defn- sidebar [{:keys [prefix-route queues queue]}]
+  [:div#sidebar
+   [:h3 "Queues"]
+   [:div.queue-list
+    [:ul
+     (for [q queues]
+       [:a {:href  (prefix-route "/enqueued/queue/" q)
+            :class (when (= q queue) "highlight")}
+        [:li.queue-list-item q]])]]])
+
+(defn- enqueued-jobs-table [jobs]
+  [:table.job-table
+   [:thead
+    [:tr
+     [:th.id-h "Id"]
+     [:th.execute-fn-sym-h "Execute fn symbol"]
+     [:th.args-h "Args"]
+     [:th.enqueued-at-h "Enqueued-at"]]]
+   [:tbody
+    (for [{:keys [id execute-fn-sym args enqueued-at]} jobs]
+      [:tr
+       [:td.id id]
+       [:td.execute-fn-sym execute-fn-sym]
+       [:td.args (string/join ", " args)]
+       [:td.enqueued-at (Date. ^Long enqueued-at)]])]])
+
+(defn pagination-stats [first-page curr-page last-page]
+  {:first-page first-page
+   :prev-page  (dec curr-page)
+   :curr-page  curr-page
+   :next-page  (inc curr-page)
+   :last-page  last-page})
+
+(defn- pagination [{:keys [prefix-route queue page total-jobs]}]
+  (let [{:keys [first-page prev-page curr-page
+                next-page last-page]} (pagination-stats d/page page
+                                                        (Math/ceilDiv ^Integer total-jobs ^Integer d/page-size))
+        page-uri (fn [p] (prefix-route "/enqueued/queue/" queue "?page=" p))
+        hyperlink (fn [page label visible? disabled? & class]
+                    (when visible?
+                      [:a {:class (conj class (when disabled? "disabled"))
+                           :href  (page-uri page)} label]))
+        single-page? (<= total-jobs d/page-size)]
+    [:div
+     (hyperlink first-page (hiccup-util/escape-html "<<") (not single-page?) (= curr-page first-page))
+     (hyperlink prev-page prev-page (> curr-page first-page) false)
+     (hyperlink curr-page curr-page (not single-page?) true "highlight")
+     (hyperlink next-page next-page (< curr-page last-page) false)
+     (hyperlink last-page (hiccup-util/escape-html ">>") (not single-page?) (= curr-page last-page))]))
+
+(defn confirmation-dialog [{:keys [prefix-route queue]}]
+  [:dialog {:class "purge-dialog"}
+   [:div "Are you sure, you want to purge the " [:span.highlight queue] " queue?"]
+   [:form {:action (prefix-route "/enqueued/queue/" queue)
+           :method "post"
+           :class  "dialog-btns"}
+    [:input {:name "_method" :type "hidden" :value "delete"}]
+    [:input {:name "queue" :value queue :type "hidden"}]
+    [:input {:type "button" :value "Cancel" :class "btn btn-md btn-cancel cancel"}]
+    [:input {:type "submit" :value "Confirm" :class "btn btn-danger btn-md"}]]])
+
+(defn- enqueued-page-view [{:keys [jobs total-jobs] :as data}]
+  [:div.redis-enqueued-main-content
+   [:h1 "Enqueued Jobs"]
+   [:div.content
+    (sidebar data)
+    [:div.right-side
+     [:div.pagination
+      (pagination data)]
+     (enqueued-jobs-table jobs)
+     (when (> total-jobs 0)
+       [:div.bottom
+        (confirmation-dialog data)
+        [:button {:class "btn btn-danger btn-lg purge-dialog-show"} "Purge"]])]]])
+
+(defn page [{:keys                     [prefix-route]
+             {:keys [app-name broker]} :console-opts
+             {:keys [page]}            :params
+             {:keys [queue]}           :route-params}]
+  (let [view (c/layout c/header enqueued-page-view)
+        data (data/enqueued-page-data (:redis-conn broker) queue page)]
+    (response/response (view "Enqueued" (assoc data :app-name app-name
+                                                    :prefix-route prefix-route)))))
+
+(defn purge-queue [{{:keys [broker]} :console-opts
+                    {:keys [queue]}  :params
+                    :keys            [prefix-route]}]
+  (enqueued-jobs/purge (:redis-conn broker) queue)
+  (response/redirect (prefix-route "/enqueued")))

--- a/src/goose/brokers/redis/console/pages/home.clj
+++ b/src/goose/brokers/redis/console/pages/home.clj
@@ -1,0 +1,23 @@
+(ns goose.brokers.redis.console.pages.home
+  (:require [ring.util.response :as response]
+            [goose.brokers.redis.console.pages.components :as c]
+            [goose.brokers.redis.console.data :as data]))
+
+(defn- stats-bar [{:keys [prefix-route] :as page-data}]
+  [:main
+   [:section.statistics
+    (for [{:keys [id label route]} [{:id :enqueued :label "Enqueued" :route "/enqueued"}
+                                    {:id :scheduled :label "Scheduled" :route "/scheduled"}
+                                    {:id :periodic :label "Periodic" :route "/periodic"}
+                                    {:id :dead :label "Dead" :route "/dead"}]]
+      [:div.stat {:id id}
+       [:span.number (str (get page-data id))]
+       [:a {:href (prefix-route route)}
+        [:span.label label]]])]])
+
+(defn page [{:keys                     [prefix-route]
+                  {:keys [app-name broker]} :console-opts}]
+  (let [view (c/layout c/header stats-bar)
+        data (data/jobs-size (:redis-conn broker))]
+    (response/response (view "Home" (assoc data :app-name app-name
+                                                :prefix-route prefix-route)))))

--- a/src/goose/brokers/redis/console/specs.clj
+++ b/src/goose/brokers/redis/console/specs.clj
@@ -1,0 +1,13 @@
+(ns goose.brokers.redis.console.specs
+  (:require [clojure.spec.alpha :as s])
+  (:import
+    (java.lang Long)))
+
+(s/def ::page (s/and pos-int?))
+
+(defn str->long
+  [str]
+  (if (= (type str) Long)
+    str
+    (try (Long/parseLong str)
+         (catch Exception _ :clojure.spec.alpha/invalid))))

--- a/src/goose/console.clj
+++ b/src/goose/console.clj
@@ -3,14 +3,27 @@
             [ring.middleware.keyword-params :as ring-keyword-params]
             [ring.middleware.params :as ring-params]))
 
-(defn- wrap-prefix-route [handler]
+(defn- wrap-prefix-route
+  "Middleware that injects a `prefix-route` function into the request,
+  that facilitates URL construction in views by prepending given route-prefix to paths"
+  [handler]
   (fn [{{:keys [route-prefix]} :console-opts
         :as req}]
     (let [prefix-route-fn (partial str route-prefix)]
       (handler (assoc req :prefix-route prefix-route-fn)))))
 
+(defn wrap-method-override
+  "Middleware to override HTTP method based on the `_method` parameters in request params, allowing
+  to simulate PUT, DELETE, PATCH etc. methods that are not supported in HTML forms"
+  [handler]
+  (fn [request]
+    (if-let [overridden-method (get-in request [:params :_method])]
+      (handler (assoc request :request-method (keyword overridden-method)))
+      (handler request))))
+
 (defn app-handler [{:keys [broker] :as console-opts} req]
   ((-> (partial b/handler broker)
        wrap-prefix-route
+       wrap-method-override
        ring-keyword-params/wrap-keyword-params
        ring-params/wrap-params) (assoc req :console-opts console-opts)))

--- a/src/goose/console.clj
+++ b/src/goose/console.clj
@@ -3,8 +3,14 @@
             [ring.middleware.keyword-params :as ring-keyword-params]
             [ring.middleware.params :as ring-params]))
 
+(defn- wrap-prefix-route [handler]
+  (fn [{{:keys [route-prefix]} :console-opts
+        :as req}]
+    (let [prefix-route-fn (partial str route-prefix)]
+      (handler (assoc req :prefix-route prefix-route-fn)))))
 
 (defn app-handler [{:keys [broker] :as console-opts} req]
   ((-> (partial b/handler broker)
+       wrap-prefix-route
        ring-keyword-params/wrap-keyword-params
        ring-params/wrap-params) (assoc req :console-opts console-opts)))

--- a/src/goose/defaults.clj
+++ b/src/goose/defaults.clj
@@ -75,3 +75,8 @@
 (def ^:no-doc rmq-delay-exchange-type "x-delayed-message")
 (def ^:no-doc rmq-low-priority 0)
 (def ^:no-doc rmq-high-priority 1)
+
+;;; ======== Console ========
+
+(def page-size 10)
+(def page "1")

--- a/src/goose/defaults.clj
+++ b/src/goose/defaults.clj
@@ -79,4 +79,4 @@
 ;;; ======== Console ========
 
 (def page-size 10)
-(def page "1")
+(def page 1)

--- a/test/goose/brokers/redis/console/data_test.clj
+++ b/test/goose/brokers/redis/console/data_test.clj
@@ -1,0 +1,52 @@
+(ns goose.brokers.redis.console.data-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [goose.brokers.redis.console.data :as console]
+            [goose.defaults :as d]
+            [goose.factories :as f]
+            [goose.test-utils :as tu]))
+
+(deftest jobs-size-test
+  (testing "Should return job size for enqueued, scheduled, periodic and dead jobs"
+    (is (= (console/jobs-size tu/redis-conn) {:enqueued 0 :scheduled 0
+                                              :periodic 0 :dead 0}))
+    (f/create-jobs {:enqueued 2 :scheduled 3 :periodic 2 :dead 3})
+    (is (= (console/jobs-size tu/redis-conn) {:enqueued 2 :scheduled 3
+                                              :periodic 2 :dead 3})))
+  (tu/clear-redis)
+  (testing "Should return jobs size given jobs exist in multiple queues"
+    (f/create-jobs {:enqueued 3 :scheduled 3 :periodic 1 :dead 1}
+                   {:enqueued {:queue       "queue1"
+                               :ready-queue "goose/queue:queue1"}})
+    (is (= (console/jobs-size tu/redis-conn) {:enqueued 3 :scheduled 3 :periodic 1 :dead 1}))))
+
+(deftest enqueued-page-data-test
+  (testing "Should get enqueued-jobs page data i.e :total-jobs, total-jobs count, all queues, current queue and page"
+    (f/create-jobs {:enqueued 2})
+    (let [{:keys [queues page queue jobs total-jobs]} (console/enqueued-page-data tu/redis-conn tu/queue "1")]
+      (is (= [tu/queue] queues))
+      (is (= 1 page))
+      (is (= tu/queue queue))
+      (is (= 2 (count jobs)))
+      (is (= 2 total-jobs))))
+  (testing "Should default page value to 1 given no page value"
+    (is (= 1 (:page (console/enqueued-page-data tu/redis-conn tu/queue nil)))))
+  (tu/clear-redis)
+  (testing "Should get at-max page-size jobs given >page-size jobs in redis"
+    (f/create-jobs {:enqueued 8})
+    (with-redefs [d/page-size 3]
+      (let [{:keys [page jobs total-jobs]} (console/enqueued-page-data tu/redis-conn tu/queue "2")]
+        (is (= 2 page))
+        (is (= 3 (count jobs)))
+        (is (= 8 total-jobs)))
+      (is (= 2 (-> (console/enqueued-page-data tu/redis-conn tu/queue "3") (get :jobs) count)))))
+  (tu/clear-redis)
+  (testing "Should get name of all the queues"
+    (f/create-async-job)
+    (f/create-async-job {:queue       "queue1"
+                         :ready-queue "goose/queue:queue1"})
+    (is (true? (every? #{tu/queue "queue1"} (-> (console/enqueued-page-data tu/redis-conn tu/queue nil) (get :queues))))))
+  (tu/clear-redis)
+  (testing "Should get no jobs data given no jobs exist in redis"
+    (let [{:keys [jobs total-jobs]} (console/enqueued-page-data tu/redis-conn tu/queue nil)]
+      (is (= [] jobs))
+      (is (= 0 total-jobs)))))

--- a/test/goose/brokers/redis/console/page_test.clj
+++ b/test/goose/brokers/redis/console/page_test.clj
@@ -1,0 +1,50 @@
+(ns goose.brokers.redis.console.page-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [goose.brokers.redis.api.enqueued-jobs :as enqueued-jobs]
+            [goose.brokers.redis.console :as console]
+            [goose.brokers.redis.console.pages.enqueued :as enqueued]
+            [goose.brokers.redis.console.pages.home :as home]
+            [goose.factories :as f]
+            [goose.test-utils :as tu]
+            [ring.mock.request :as mock]
+            [spy.core :as spy]))
+
+(use-fixtures :each tu/redis-fixture)
+
+(deftest purge-queue-test
+  (testing "Should purge a queue"
+    (f/create-async-job)
+    (f/create-async-job {:queue       "queue1"
+                         :ready-queue "goose/queue:queue1"})
+    (is (true? (every? #{tu/queue "queue1"} (enqueued-jobs/list-all-queues tu/redis-conn))))
+    (is (= 2 (count (enqueued-jobs/list-all-queues tu/redis-conn))))
+    (is (= {:body    ""
+            :headers {"Location" "/enqueued"}
+            :status  302} (enqueued/purge-queue {:console-opts tu/redis-console-opts
+                                                 :params       {:queue tu/queue}
+                                                 :prefix-route str})))
+    (is (= ["queue1"] (enqueued-jobs/list-all-queues tu/redis-conn)))))
+
+(deftest page-handler-test
+  (testing "Main handler should invoke home-page handler"
+    (with-redefs [home/page (spy/stub {:status 200 :body "Mocked resp"})]
+      (console/handler tu/redis-producer (mock/request :get ""))
+      (true? (spy/called-once? home/page))
+      (is (= [{:status 200
+               :body   "Mocked resp"}] (spy/responses home/page)))))
+  (testing "Main Handler should invoke enqueued-page handler"
+    (with-redefs [enqueued/page (spy/stub {:status 200 :body "Mocked resp"})]
+      (console/handler tu/redis-producer (mock/request :get "/enqueued"))
+      (true? (spy/called-once? enqueued/page))
+      (is (= [{:status 200
+               :body   "Mocked resp"}] (spy/responses enqueued/page))))
+    (with-redefs [enqueued/page (spy/stub {:status 200 :body "Mocked resp"})]
+      (console/handler tu/redis-producer (mock/request :get "/enqueued/queue/default"))
+      (true? (spy/called-once? enqueued/page))
+      (is (= [{:status 200
+               :body   "Mocked resp"}] (spy/responses enqueued/page)))
+      (is (= "default" (get-in (first (spy/first-call enqueued/page)) [:route-params :queue]))))
+    (with-redefs [enqueued/purge-queue (spy/stub {:status 302 :headers {"Location" "/enqueued"} :body ""})]
+      (console/handler tu/redis-producer (mock/request :delete "/enqueued/queue/default"))
+      (true? (spy/called-once? enqueued/purge-queue))
+      (is (= [{:status 302 :headers {"Location" "/enqueued"} :body ""}] (spy/responses enqueued/purge-queue))))))

--- a/test/goose/brokers/redis/console_test.clj
+++ b/test/goose/brokers/redis/console_test.clj
@@ -1,131 +1,43 @@
 (ns goose.brokers.redis.console-test
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
-            [goose.brokers.redis.console :as redis-console]
-            [goose.brokers.redis.api.enqueued-jobs :as enqueued-jobs]
-            [goose.defaults :as d]
-            [goose.factories :as f]
+            [goose.brokers.redis.console :as console]
             [goose.test-utils :as tu]
-            [ring.mock.request :as mock]
-            [spy.core :as spy])
+            [ring.mock.request :as mock])
   (:import (java.io File)))
 
 (use-fixtures :each tu/redis-fixture)
 
-(deftest jobs-size-test
-  (testing "Should return job size for enqueued, scheduled, periodic and dead jobs"
-    (is (= (redis-console/jobs-size tu/redis-conn) {:enqueued 0 :scheduled 0
-                                                    :periodic 0 :dead 0}))
-    (f/create-jobs {:enqueued 2 :scheduled 3 :periodic 2 :dead 3})
-    (is (= (redis-console/jobs-size tu/redis-conn) {:enqueued 2 :scheduled 3
-                                                    :periodic 2 :dead 3})))
-  (tu/clear-redis)
-  (testing "Should return jobs size given jobs exist in multiple queues"
-    (f/create-jobs {:enqueued 3 :scheduled 3 :periodic 1 :dead 1}
-                   {:enqueued {:queue       "queue1"
-                               :ready-queue "goose/queue:queue1"}})
-    (is (= (redis-console/jobs-size tu/redis-conn) {:enqueued 3 :scheduled 3 :periodic 1 :dead 1}))))
-
-(deftest enqueued-page-data-test
-  (testing "Should get enqueued-jobs page data i.e :total-jobs, total-jobs count, all queues, current queue and page"
-    (f/create-jobs {:enqueued 2})
-    (let [{:keys [queues page queue jobs total-jobs]} (redis-console/enqueued-page-data tu/redis-conn tu/queue "1")]
-      (is (= [tu/queue] queues))
-      (is (= 1 page))
-      (is (= tu/queue queue))
-      (is (= 2 (count jobs)))
-      (is (= 2 total-jobs))))
-  (testing "Should default page value to 1 given no page value"
-    (is (= 1 (:page (redis-console/enqueued-page-data tu/redis-conn tu/queue nil)))))
-  (tu/clear-redis)
-  (testing "Should get at-max page-size jobs given >page-size jobs in redis"
-    (f/create-jobs {:enqueued 8})
-    (with-redefs [d/page-size 3]
-      (let [{:keys [page jobs total-jobs]} (redis-console/enqueued-page-data tu/redis-conn tu/queue "2")]
-        (is (= 2 page))
-        (is (= 3 (count jobs)))
-        (is (= 8 total-jobs)))
-      (is (= 2 (-> (redis-console/enqueued-page-data tu/redis-conn tu/queue "3") (get :jobs) count)))))
-  (tu/clear-redis)
-  (testing "Should get name of all the queues"
-    (f/create-async-job)
-    (f/create-async-job {:queue       "queue1"
-                         :ready-queue "goose/queue:queue1"})
-    (is (true? (every? #{tu/queue "queue1"} (-> (redis-console/enqueued-page-data tu/redis-conn tu/queue nil) (get :queues))))))
-  (tu/clear-redis)
-  (testing "Should get no jobs data given no jobs exist in redis"
-    (let [{:keys [jobs total-jobs]} (redis-console/enqueued-page-data tu/redis-conn tu/queue nil)]
-      (is (= [] jobs))
-      (is (= 0 total-jobs)))))
-
-(deftest purge-queue-test
-  (testing "Should purge a queue"
-    (f/create-async-job)
-    (f/create-async-job {:queue       "queue1"
-                         :ready-queue "goose/queue:queue1"})
-    (is (true? (every? #{tu/queue "queue1"} (enqueued-jobs/list-all-queues tu/redis-conn))))
-    (is (= 2 (count (enqueued-jobs/list-all-queues tu/redis-conn))))
-    (is (= {:body    ""
-            :headers {"Location" "/enqueued"}
-            :status  302} (redis-console/purge-queue {:console-opts tu/redis-console-opts
-                                                      :params       {:queue tu/queue}
-                                                      :prefix-route str})))
-    (is (= ["queue1"] (enqueued-jobs/list-all-queues tu/redis-conn)))))
-
-(deftest page-handler-test
-  (testing "Main handler should invoke home-page handler"
-    (with-redefs [redis-console/home-page (spy/stub {:status 200 :body "Mocked resp"})]
-      (redis-console/handler tu/redis-producer (mock/request :get ""))
-      (true? (spy/called-once? redis-console/home-page))
-      (is (= [{:status 200
-               :body   "Mocked resp"}] (spy/responses redis-console/home-page)))))
-  (testing "Main Handler should invoke enqueued-page handler"
-    (with-redefs [redis-console/enqueued-page (spy/stub {:status 200 :body "Mocked resp"})]
-      (redis-console/handler tu/redis-producer (mock/request :get "/enqueued"))
-      (true? (spy/called-once? redis-console/enqueued-page))
-      (is (= [{:status 200
-               :body   "Mocked resp"}] (spy/responses redis-console/enqueued-page))))
-    (with-redefs [redis-console/enqueued-page (spy/stub {:status 200 :body "Mocked resp"})]
-      (redis-console/handler tu/redis-producer (mock/request :get "/enqueued/queue/default"))
-      (true? (spy/called-once? redis-console/enqueued-page))
-      (is (= [{:status 200
-               :body   "Mocked resp"}] (spy/responses redis-console/enqueued-page)))
-      (is (= "default" (get-in (first (spy/first-call redis-console/enqueued-page)) [:route-params :queue]))))
-    (with-redefs [redis-console/purge-queue (spy/stub {:status 302 :headers {"Location" "/enqueued"} :body ""})]
-      (redis-console/handler tu/redis-producer (mock/request :delete "/enqueued/queue/default"))
-      (true? (spy/called-once? redis-console/purge-queue))
-      (is (= [{:status 302 :headers {"Location" "/enqueued"} :body ""}] (spy/responses redis-console/purge-queue))))))
-
 (deftest handler-test
   (testing "Should serve css file on GET request at /css/style.css route"
-    (let [response (redis-console/handler tu/redis-producer (-> (mock/request :get "goose/console/css/style.css")
-                                                                (assoc :console-opts {:broker       tu/redis-producer
-                                                                                      :app-name     ""
-                                                                                      :route-prefix "goose/console"})))]
+    (let [response (console/handler tu/redis-producer (-> (mock/request :get "goose/console/css/style.css")
+                                                          (assoc :console-opts {:broker       tu/redis-producer
+                                                                                :app-name     ""
+                                                                                :route-prefix "goose/console"})))]
       (is (= (:status response) 200))
       (is (= (type (:body response)) File))
       (is (= (get-in response [:headers "Content-Type"]) "text/css"))))
   (testing "Should serve goose logo on GET request at /img/goose-logo.png route"
-    (let [response (redis-console/handler tu/redis-producer (-> (mock/request :get "foo/img/goose-logo.png")
-                                                                (assoc :console-opts {:broker       tu/redis-producer
-                                                                                      :app-name     ""
-                                                                                      :route-prefix "foo"})))]
+    (let [response (console/handler tu/redis-producer (-> (mock/request :get "foo/img/goose-logo.png")
+                                                          (assoc :console-opts {:broker       tu/redis-producer
+                                                                                :app-name     ""
+                                                                                :route-prefix "foo"})))]
       (is (= (:status response) 200))
       (is (= (type (:body response)) File))
       (is (= (get-in response [:headers "Content-Type"]) "image/png"))))
   (testing "Should redirect to main route with slash (goose/console/) on GET req to route without slash(goose/console)"
-    (is (= (redis-console/handler tu/redis-producer (-> (mock/request :get "foo")
-                                                        (assoc :console-opts {:broker       tu/redis-producer
-                                                                              :app-name     ""
-                                                                              :route-prefix "foo"}
-                                                               :prefix-route (partial str "foo"))))
+    (is (= (console/handler tu/redis-producer (-> (mock/request :get "foo")
+                                                  (assoc :console-opts {:broker       tu/redis-producer
+                                                                        :app-name     ""
+                                                                        :route-prefix "foo"}
+                                                         :prefix-route (partial str "foo"))))
            {:status  302
             :headers {"Location" "foo/"}
             :body    ""})))
   (testing "Should show not-found page given invalid route"
-    (is (= (redis-console/handler tu/redis-producer (-> (mock/request :get "foo/invalid")
-                                                        (assoc :console-opts {:broker       tu/redis-producer
-                                                                              :app-name     ""
-                                                                              :route-prefix "foo"})))
+    (is (= (console/handler tu/redis-producer (-> (mock/request :get "foo/invalid")
+                                                  (assoc :console-opts {:broker       tu/redis-producer
+                                                                        :app-name     ""
+                                                                        :route-prefix "foo"})))
            {:body    "<div> Not found </div>"
             :headers {}
             :status  404}))))

--- a/test/goose/brokers/redis/console_test.clj
+++ b/test/goose/brokers/redis/console_test.clj
@@ -43,7 +43,8 @@
     (is (= (redis-console/handler tu/redis-producer (-> (mock/request :get "foo")
                                                         (assoc :console-opts {:broker       tu/redis-producer
                                                                               :app-name     ""
-                                                                              :route-prefix "foo"})))
+                                                                              :route-prefix "foo"}
+                                                               :prefix-route (partial str "foo"))))
            {:status  302
             :headers {"Location" "foo/"}
             :body    ""})))

--- a/test/goose/brokers/redis/console_test.clj
+++ b/test/goose/brokers/redis/console_test.clj
@@ -1,9 +1,11 @@
 (ns goose.brokers.redis.console-test
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [goose.brokers.redis.console :as redis-console]
+            [goose.defaults :as d]
             [goose.factories :as f]
             [goose.test-utils :as tu]
-            [ring.mock.request :as mock])
+            [ring.mock.request :as mock]
+            [spy.core :as spy])
   (:import (java.io File)))
 
 (use-fixtures :each tu/redis-fixture)
@@ -18,9 +20,61 @@
   (tu/clear-redis)
   (testing "Should return jobs size given jobs exist in multiple queues"
     (f/create-jobs {:enqueued 3 :scheduled 3 :periodic 1 :dead 1}
-                {:enqueued {:queue       "queue1"
-                            :ready-queue "goose/queue:queue1"}})
+                   {:enqueued {:queue       "queue1"
+                               :ready-queue "goose/queue:queue1"}})
     (is (= (redis-console/jobs-size tu/redis-conn) {:enqueued 3 :scheduled 3 :periodic 1 :dead 1}))))
+
+(deftest enqueued-page-data-test
+  (testing "Should get enqueued-jobs page data i.e :total-jobs, total-jobs count, all queues, current queue and page"
+    (f/create-jobs {:enqueued 2})
+    (let [{:keys [queues page queue jobs total-jobs]} (redis-console/enqueued-page-data tu/redis-conn tu/queue "1")]
+      (is (= [tu/queue] queues))
+      (is (= 1 page))
+      (is (= tu/queue queue))
+      (is (= 2 (count jobs)))
+      (is (= 2 total-jobs))))
+  (testing "Should default page value to 1 given no page value"
+    (is (= 1 (:page (redis-console/enqueued-page-data tu/redis-conn tu/queue nil)))))
+  (tu/clear-redis)
+  (testing "Should get at-max page-size jobs given >page-size jobs in redis"
+    (f/create-jobs {:enqueued 8})
+    (with-redefs [d/page-size 3]
+      (let [{:keys [page jobs total-jobs]} (redis-console/enqueued-page-data tu/redis-conn tu/queue "2")]
+        (is (= 2 page))
+        (is (= 3 (count jobs)))
+        (is (= 8 total-jobs)))
+      (is (= 2 (-> (redis-console/enqueued-page-data tu/redis-conn tu/queue "3") (get :jobs) count)))))
+  (tu/clear-redis)
+  (testing "Should get name of all the queues"
+    (f/create-async-job)
+    (f/create-async-job {:queue       "queue1"
+                         :ready-queue "goose/queue:queue1"})
+    (is (= [tu/queue "queue1"] (-> (redis-console/enqueued-page-data tu/redis-conn tu/queue nil) (get :queues)))))
+  (tu/clear-redis)
+  (testing "Should get no jobs data given no jobs exist in redis"
+    (let [{:keys [jobs total-jobs]} (redis-console/enqueued-page-data tu/redis-conn tu/queue nil)]
+      (is (= [] jobs))
+      (is (= 0 total-jobs)))))
+
+(deftest page-handler-test
+  (testing "Main handler should invoke home-page handler"
+    (with-redefs [redis-console/home-page (spy/stub {:status 200 :body "Mocked resp"})]
+      (redis-console/handler tu/redis-producer (mock/request :get ""))
+      (true? (spy/called-once? redis-console/home-page))
+      (is (= [{:status 200
+               :body   "Mocked resp"}] (spy/responses redis-console/home-page)))))
+  (testing "Main Handler should invoke enqueued-page handler"
+    (with-redefs [redis-console/enqueued-page (spy/stub {:status 200 :body "Mocked resp"})]
+      (redis-console/handler tu/redis-producer (mock/request :get "/enqueued"))
+      (true? (spy/called-once? redis-console/enqueued-page))
+      (is (= [{:status 200
+               :body   "Mocked resp"}] (spy/responses redis-console/enqueued-page))))
+    (with-redefs [redis-console/enqueued-page (spy/stub {:status 200 :body "Mocked resp"})]
+      (redis-console/handler tu/redis-producer (mock/request :get "/enqueued/queue/default"))
+      (true? (spy/called-once? redis-console/enqueued-page))
+      (is (= [{:status 200
+               :body   "Mocked resp"}] (spy/responses redis-console/enqueued-page)))
+      (is (= "default" (get-in (first (spy/first-call redis-console/enqueued-page)) [:route-params :queue]))))))
 
 (deftest handler-test
   (testing "Should serve css file on GET request at /css/style.css route"

--- a/test/goose/console_test.clj
+++ b/test/goose/console_test.clj
@@ -85,7 +85,8 @@
   (let [req-with-client-opts (assoc (mock/request :get "foo/")
                                :console-opts {:broker       tu/redis-producer
                                               :app-name     ""
-                                              :route-prefix "foo"})]
+                                              :route-prefix "foo"}
+                               :prefix-route (partial str "foo"))]
     (testing "Should call redis-handler given redis-broker"
       (with-redefs [redis-console/handler (spy/spy redis-console/handler)]
         (is (true? (spy/not-called? redis-console/handler)))

--- a/test/goose/console_test.clj
+++ b/test/goose/console_test.clj
@@ -1,7 +1,6 @@
 (ns goose.console-test
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [goose.broker :as broker]
-            [goose.brokers.redis.broker :as redis]
             [goose.brokers.redis.console :as redis-console]
             [goose.client :as c]
             [goose.console :as console]


### PR DESCRIPTION
Current view of enqueued jobs (without pagination)
<img width="500" alt="image" src="https://github.com/nilenso/goose/assets/36623306/497e8203-0661-4e31-a2d9-81d056256033">

With pagination:
<img width="500" alt="image" src="https://github.com/nilenso/goose/assets/36623306/f75243a3-6f2e-49b6-9802-30eeaead70c6">

