### PR TITLE
Miscellaneous changes

### DIFF
--- a/src/goose/brokers/redis/console.clj
+++ b/src/goose/brokers/redis/console.clj
@@ -7,7 +7,6 @@
             [hiccup.page :refer [html5 include-css]]
             [ring.util.response :as response]))
 
-
 (defn- layout [& components]
   (fn [title data]
     (html5 [:head
@@ -19,20 +18,23 @@
             (map (fn [c] (c data)) components)])))
 
 (defn- header [{:keys [app-name] :or {app-name ""}}]
-  [:header
-   [:nav
-    [:div.nav-start
-     [:div.goose-logo
-      [:a {:href ""}
-       [:img {:src "img/goose-logo.png" :alt "goose-logo"}]]]
-     [:a {:href ""}
-      [:div#app-name app-name]]
-     [:div#menu
-      [:a {:href "enqueued"} "Enqueued"]
-      [:a {:href "scheduled"} "Scheduled"]
-      [:a {:href "periodic"} "Periodic"]
-      [:a {:href "batch"} "Batch"]
-      [:a {:href "dead"} "Dead"]]]]])
+  (let [short-app-name (if (> (count app-name) 20)
+                         (str (subs app-name 0 17) "..")
+                         app-name)]
+    [:header
+     [:nav
+      [:div.nav-start
+       [:div.goose-logo
+        [:a {:href ""}
+         [:img {:src "img/goose-logo.png" :alt "goose-logo"}]]]
+       [:a {:href ""}
+        [:div#app-name short-app-name]]
+       [:div#menu
+        [:a {:href "enqueued"} "Enqueued"]
+        [:a {:href "scheduled"} "Scheduled"]
+        [:a {:href "periodic"} "Periodic"]
+        [:a {:href "batch"} "Batch"]
+        [:a {:href "dead"} "Dead"]]]]]))
 
 (defn- stats-bar [page-data]
   [:main

--- a/src/goose/brokers/redis/console.clj
+++ b/src/goose/brokers/redis/console.clj
@@ -60,13 +60,13 @@
      :periodic  periodic
      :dead      dead}))
 
-(defn home-page [broker {{:keys [app-name]} :client-opts}]
+(defn home-page [broker {{:keys [app-name]} :console-opts}]
   (let [view (layout header stats-bar)
         data (jobs-size (:redis-conn broker))]
     (response/response (view "Home" (assoc data :app-name app-name)))))
 
 (defn handler [broker {:keys                  [uri]
-                       {:keys [route-prefix]} :client-opts
+                       {:keys [route-prefix]} :console-opts
                        :as                    req}]
   (let [path (string/replace uri (re-pattern route-prefix) "")]
     (case path

--- a/src/goose/console.clj
+++ b/src/goose/console.clj
@@ -1,8 +1,5 @@
 (ns goose.console
   (:require [goose.broker :as b]))
 
-(defn- handler [{{:keys [broker]} :console-opts :as req}]
-  (b/handler broker req))
-
-(defn app-handler [console-opts req]
-  (handler (assoc req :console-opts console-opts)))
+(defn app-handler [{:keys [broker] :as console-opts} req]
+  (b/handler broker (assoc req :console-opts console-opts)))

--- a/src/goose/console.clj
+++ b/src/goose/console.clj
@@ -1,8 +1,8 @@
 (ns goose.console
   (:require [goose.broker :as b]))
 
-(defn- handler [{{:keys [broker]} :client-opts :as req}]
+(defn- handler [{{:keys [broker]} :console-opts :as req}]
   (b/handler broker req))
 
-(defn app-handler [client-opts req]
-  (handler (assoc req :client-opts client-opts)))
+(defn app-handler [console-opts req]
+  (handler (assoc req :console-opts console-opts)))

--- a/src/goose/specs.clj
+++ b/src/goose/specs.clj
@@ -185,7 +185,7 @@
                    ::metrics-plugin]))
 
 ;;; ============== Console ============
-(s/def ::app-name (s/and string? #(< (count %) 8)))
+(s/def ::app-name string?)
 (s/def ::route-prefix string?)
 (s/def ::console-opts (s/keys :req-un [::route-prefix
                                        ::broker

--- a/src/goose/specs.clj
+++ b/src/goose/specs.clj
@@ -190,9 +190,6 @@
 (s/def ::console-opts (s/keys :req-un [::route-prefix
                                        ::broker
                                        ::app-name]))
-(s/fdef console/app-handler
-        :args (s/cat :client-opts ::console-opts
-                     :req map?))
 
 ;;; ============== FDEFs ==============
 (s/fdef c/perform-async
@@ -228,6 +225,10 @@
                      :execute-fn-sym ::fn-sym
                      :args ::batch-args)
         :ret map?)
+
+(s/fdef console/app-handler
+        :args (s/cat :console-opts ::console-opts
+                     :req map?))
 
 (def ^:private fns-with-specs
   [`c/perform-async

--- a/test/goose/brokers/redis/commands_test.clj
+++ b/test/goose/brokers/redis/commands_test.clj
@@ -84,7 +84,7 @@
     (is (= ["foo2" "foo3"] (redis-cmds/range-from-front tu/redis-conn "my-list" 2 3)))
     (is (= ["foo2" "foo3" "foo4"] (redis-cmds/range-from-front tu/redis-conn "my-list" 2 6)))))
 
-(deftest del-from-list-multiple-test
+(deftest del-from-list-test
   (testing "should delete multiple members from list"
     (let [list-members (map #(str "foo" %) (range 5))]
       (doseq [member list-members]
@@ -95,7 +95,7 @@
     (is (= [1] (redis-cmds/del-from-list tu/redis-conn "my-list" "foo3")))
     (is (= ["foo2" "foo4"] (redis-cmds/range-from-front tu/redis-conn "my-list" 0 1)))))
 
-(deftest del-from-list-and-enqueue-front-multiple-test
+(deftest del-from-list-and-enqueue-front-test
   (testing "should prioritise execution of multiple jobs"
     (let [list-members (map #(str "foo" %) (range 5))]
       (doseq [member list-members]

--- a/test/goose/brokers/redis/console_test.clj
+++ b/test/goose/brokers/redis/console_test.clj
@@ -24,33 +24,33 @@
 (deftest handler-test
   (testing "Should serve css file on GET request at /css/style.css route"
     (let [response (redis-console/handler tu/redis-producer (-> (mock/request :get "/goose/console/css/style.css")
-                                                                (assoc :client-opts {:broker       tu/redis-producer
-                                                                                     :app-name     ""
-                                                                                     :route-prefix "goose/console/"})))]
+                                                                (assoc :console-opts {:broker       tu/redis-producer
+                                                                                      :app-name     ""
+                                                                                      :route-prefix "goose/console/"})))]
       (is (= (:status response) 200))
       (is (= (type (:body response)) File))
       (is (= (get-in response [:headers "Content-Type"]) "text/css"))))
   (testing "Should serve goose logo on GET request at img/goose-logo.png route"
     (let [response (redis-console/handler tu/redis-producer (-> (mock/request :get "foo/img/goose-logo.png")
-                                                                (assoc :client-opts {:broker       tu/redis-producer
-                                                                                     :app-name     ""
-                                                                                     :route-prefix "foo"})))]
+                                                                (assoc :console-opts {:broker       tu/redis-producer
+                                                                                      :app-name     ""
+                                                                                      :route-prefix "foo"})))]
       (is (= (:status response) 200))
       (is (= (type (:body response)) File))
       (is (= (get-in response [:headers "Content-Type"]) "image/png"))))
   (testing "Should redirect to main route with slash (goose/console/) on GET req to route without slash(goose/console)"
     (is (= (redis-console/handler tu/redis-producer (-> (mock/request :get "foo")
-                                                        (assoc :client-opts {:broker       tu/redis-producer
-                                                                             :app-name     ""
-                                                                             :route-prefix "foo"})))
+                                                        (assoc :console-opts {:broker       tu/redis-producer
+                                                                              :app-name     ""
+                                                                              :route-prefix "foo"})))
            {:status  302
             :headers {"Location" "foo/"}
             :body    ""})))
   (testing "Should show not found page given invalid route"
     (is (= (redis-console/handler tu/redis-producer (-> (mock/request :get "foo/invalid")
-                                                        (assoc :client-opts {:broker       tu/redis-producer
-                                                                             :app-name     ""
-                                                                             :route-prefix "foo"})))
+                                                        (assoc :console-opts {:broker       tu/redis-producer
+                                                                              :app-name     ""
+                                                                              :route-prefix "foo"})))
            {:body    "<div> Not found </div>"
             :headers {}
             :status  404}))))

--- a/test/goose/brokers/redis/console_test.clj
+++ b/test/goose/brokers/redis/console_test.clj
@@ -15,11 +15,12 @@
     (f/add-jobs {:enqueued 2 :scheduled 3 :periodic 2 :dead 3})
     (is (= (redis-console/jobs-size tu/redis-conn) {:enqueued 2 :scheduled 3
                                                     :periodic 2 :dead 3})))
+  (tu/clear-redis)
   (testing "Should return jobs size given jobs exist in multiple queues"
     (f/add-jobs {:enqueued 3 :scheduled 3 :periodic 1 :dead 1}
                 {:enqueued {:queue       "queue1"
                             :ready-queue "goose/queue:queue1"}})
-    (is (= (redis-console/jobs-size tu/redis-conn) {:enqueued 5 :scheduled 6 :periodic 3 :dead 4}))))
+    (is (= (redis-console/jobs-size tu/redis-conn) {:enqueued 3 :scheduled 3 :periodic 1 :dead 1}))))
 
 (deftest handler-test
   (testing "Should serve css file on GET request at /css/style.css route"

--- a/test/goose/brokers/redis/console_test.clj
+++ b/test/goose/brokers/redis/console_test.clj
@@ -12,12 +12,12 @@
   (testing "Should return job size for enqueued, scheduled, periodic and dead jobs"
     (is (= (redis-console/jobs-size tu/redis-conn) {:enqueued 0 :scheduled 0
                                                     :periodic 0 :dead 0}))
-    (f/add-jobs {:enqueued 2 :scheduled 3 :periodic 2 :dead 3})
+    (f/create-jobs {:enqueued 2 :scheduled 3 :periodic 2 :dead 3})
     (is (= (redis-console/jobs-size tu/redis-conn) {:enqueued 2 :scheduled 3
                                                     :periodic 2 :dead 3})))
   (tu/clear-redis)
   (testing "Should return jobs size given jobs exist in multiple queues"
-    (f/add-jobs {:enqueued 3 :scheduled 3 :periodic 1 :dead 1}
+    (f/create-jobs {:enqueued 3 :scheduled 3 :periodic 1 :dead 1}
                 {:enqueued {:queue       "queue1"
                             :ready-queue "goose/queue:queue1"}})
     (is (= (redis-console/jobs-size tu/redis-conn) {:enqueued 3 :scheduled 3 :periodic 1 :dead 1}))))

--- a/test/goose/console_test.clj
+++ b/test/goose/console_test.clj
@@ -67,9 +67,9 @@
 
 (deftest handler-test
   (let [req-with-client-opts (assoc (mock/request :get "foo/")
-                               :client-opts {:broker       tu/redis-producer
-                                             :app-name     ""
-                                             :route-prefix "foo"})]
+                               :console-opts {:broker       tu/redis-producer
+                                              :app-name     ""
+                                              :route-prefix "foo"})]
     (testing "Should call redis-handler given redis-broker"
       (with-redefs [redis-console/handler (spy/spy redis-console/handler)]
         (is (true? (spy/not-called? redis-console/handler)))

--- a/test/goose/specs_test.clj
+++ b/test/goose/specs_test.clj
@@ -1,7 +1,7 @@
 (ns goose.specs-test
   (:require
     [clojure.spec.alpha :as s]
-    [clojure.test :refer [are deftest is testing]]
+    [clojure.test :refer [are deftest is]]
     [goose.batch :as batch]
     [goose.brokers.redis.broker :as redis]
     [goose.brokers.rmq.broker :as rmq]

--- a/test/goose/specs_test.clj
+++ b/test/goose/specs_test.clj
@@ -1,7 +1,7 @@
 (ns goose.specs-test
   (:require
     [clojure.spec.alpha :as s]
-    [clojure.test :refer [are deftest is]]
+    [clojure.test :refer [are deftest is testing]]
     [goose.batch :as batch]
     [goose.brokers.redis.broker :as redis]
     [goose.brokers.rmq.broker :as rmq]
@@ -11,9 +11,8 @@
     [goose.metrics.statsd :as statsd]
     [goose.specs :as specs]
     [goose.test-utils :as tu]
-    [ring.mock.request :as mock]
-
     [goose.utils :as u]
+
     [goose.worker :as w])
   (:import
     (clojure.lang ExceptionInfo)
@@ -151,15 +150,10 @@
     #(statsd/new (assoc statsd/default-opts :sample-rate 1))
     #(statsd/new (assoc statsd/default-opts :tags '("service:maverick")))
 
-    ;; :console
-    (let [opts {:broker       tu/redis-producer
-                :app-name     ""
-                :route-prefix ""}
-          req (mock/request :get "/")]
-      (console/app-handler (assoc opts :broker {}) req)
-      (console/app-handler (dissoc opts :broker) req)
-      (console/app-handler (dissoc opts :route-prefix) req)
-      (console/app-handler (dissoc opts :app-name) req)
-      (console/app-handler (assoc opts :app-name "morethan8chars") req)
-      (console/app-handler (assoc opts :app-name :invalid-type) req)
-      (console/app-handler (assoc opts :route-prefix :invalid-type) req))))
+    ;; Console
+    #(console/app-handler (assoc tu/redis-console-opts :broker {}) {})
+    #(console/app-handler (dissoc tu/redis-console-opts :broker) {})
+    #(console/app-handler (dissoc tu/redis-console-opts :app-name) {})
+    #(console/app-handler (assoc tu/redis-console-opts :app-name :invalid-type) {})
+    #(console/app-handler (dissoc tu/redis-console-opts :route-prefix) {})
+    #(console/app-handler (assoc tu/redis-console-opts :route-prefix :invalid-type) {})))

--- a/test/goose/test_utils.clj
+++ b/test/goose/test_utils.clj
@@ -55,6 +55,11 @@
 
   (clear-redis))
 
+(def redis-console-opts {:broker       redis-producer
+                         :app-name     ""
+                         :route-prefix ""})
+
+
 ;; RMQ ---------
 (def rmq-url
   (let [host (or (System/getenv "GOOSE_TEST_RABBITMQ_HOST") "localhost")


### PR DESCRIPTION
This PR addresses suggestions given by @olttwa 

Changes involve:
- Remove the app-name spec for console and enforce in UI
- Rename client-opts to console-opts or opts in the app-handler
- move (s/fdef console/app-handler) in specs below (in fdef's definition) place
- prefix factory methods with `-create`
- deconstruct args within console/app-handler fn itself
- use tu/clear-redis between 2 tests to make assertions more clear