### PR TITLE
Filter enqueued jobs

### DIFF
--- a/resources/public/css/style.css
+++ b/resources/public/css/style.css
@@ -69,6 +69,10 @@ dialog {
   font-weight: bold;
 }
 
+.cursor-default {
+  cursor: default;
+}
+
 .statistics {
   display: flex;
   justify-content: space-around;
@@ -242,8 +246,17 @@ select {
   justify-content: space-between;
 }
 
+.redis-enqueued-main-content .header .filter-opts-items .filter-type {
+  background-color: #c4d0ec;
+  color: #585454;
+}
+
+.redis-enqueued-main-content .header .filter-opts-items .filter-values{
+  display: flex;
+}
+
 .redis-enqueued-main-content .header .filter-opts-items .limit {
-  background-color: #fff;
+  background-color: #c4d0ec;
   font-size: small;
   margin: auto;
   padding: 7px 20px;

--- a/resources/public/js/index.js
+++ b/resources/public/js/index.js
@@ -1,11 +1,71 @@
 window.onload = () => {
-    const purge_dialog = document.querySelector(".purge-dialog");
-    const showDialog = document.querySelector(".purge-dialog-show")
-    const cancelDialog = document.querySelector("dialog .cancel")
-    showDialog.addEventListener("click", () => {
-        purge_dialog.showModal();
-    })
-    cancelDialog.addEventListener("click", () => {
-        purge_dialog.close();
-    })
+
+  function attachPurgeDialogEventListener() {
+    const purgeDialog = document.querySelector(".purge-dialog");
+    const showPurgeDialog = document.querySelector(".purge-dialog-show")
+    const cancelPurgeDialog = document.querySelector(".purge-dialog .cancel")
+    if (purgeDialog) {
+      showPurgeDialog.addEventListener("click", (event) => {
+        purgeDialog.showModal()
+      })
+      cancelPurgeDialog.addEventListener("click", (event) => {
+        purgeDialog.close()
+      })
+    }
+  }
+
+  function createFilterValueInputElement() {
+    const input = document.createElement("input");
+    input.setAttribute('type', 'text');
+    input.setAttribute('name', 'filter-value');
+    input.setAttribute('class', 'filter-value');
+    input.setAttribute('placeholder', 'filter value')
+    input.setAttribute('value', '');
+    return input;
+  }
+  function createFilterValueSelectElement() {
+    const select = document.createElement('select');
+    select.setAttribute('id', 'job-type-select')
+    select.setAttribute('name', 'filter-value')
+    select.setAttribute('class', 'filter-value')
+    const options = ["unexecuted", "failed"];
+    options.forEach(function (t) {
+      var option = document.createElement('option');
+      option.value = t;
+      option.textContent = t;
+      select.appendChild(option);
+    });
+    return select;
+  }
+
+  function attachFilterTypeEventListener() {
+    const SELECT_FILTER_TYPES = ["type"];
+    const INPUT_FILTER_TYPES = ["id", "execute-fn-sym"];
+    const filterTypeSelect = document.querySelector(".filter-type");
+
+    filterTypeSelect.addEventListener("change", (event) => {
+      const filterValuesDiv = document.querySelector(".filter-values");
+      const selectedFilterType = filterTypeSelect.value;
+      const currentFilterValueElement = document.querySelector(".filter-opts-items .filter-value");
+
+      let newFilterValueElement;
+
+      switch (true) {
+        case SELECT_FILTER_TYPES.includes(selectedFilterType):
+          newFilterValueElement = createFilterValueSelectElement();
+          break;
+        case INPUT_FILTER_TYPES.includes(selectedFilterType):
+          newFilterValueElement = createFilterValueInputElement();
+          break;
+      }
+
+      if (newFilterValueElement) {
+        currentFilterValueElement.remove();
+        filterValuesDiv.appendChild(newFilterValueElement);
+      }
+    });
+  }
+
+  attachPurgeDialogEventListener();
+  attachFilterTypeEventListener();
 }

--- a/src/goose/brokers/redis/console.clj
+++ b/src/goose/brokers/redis/console.clj
@@ -28,8 +28,8 @@
 (defn routes [route-prefix]
   [route-prefix [["" redirect-to-home-page]
                  ["/" home/page]
-                 ["/enqueued" {""                 enqueued/page
-                               ["/queue/" :queue] [[:get enqueued/page]
+                 ["/enqueued" {""                 enqueued/get-jobs
+                               ["/queue/" :queue] [[:get enqueued/get-jobs]
                                                    [:delete enqueued/purge-queue]]}]
                  ["/css/style.css" load-css]
                  ["/img/goose-logo.png" load-img]
@@ -47,5 +47,5 @@
                                            {:request-method
                                             request-method}))]
     (-> req
-        (assoc :route-params route-params)
+        (update :params merge route-params)
         page-handler)))

--- a/src/goose/brokers/redis/console/pages/enqueued.clj
+++ b/src/goose/brokers/redis/console/pages/enqueued.clj
@@ -3,6 +3,7 @@
             [goose.brokers.redis.api.enqueued-jobs :as enqueued-jobs]
             [goose.brokers.redis.console.data :as data]
             [goose.brokers.redis.console.pages.components :as c]
+            [goose.brokers.redis.console.specs :as specs]
             [goose.defaults :as d]
             [hiccup.util :as hiccup-util]
             [ring.util.response :as response])
@@ -32,7 +33,7 @@
     (for [{:keys [id execute-fn-sym args enqueued-at]} jobs]
       [:tr
        [:td.id id]
-       [:td.execute-fn-sym execute-fn-sym]
+       [:td.execute-fn-sym (str execute-fn-sym)]
        [:td.args (string/join ", " args)]
        [:td.enqueued-at (Date. ^Long enqueued-at)]])]])
 
@@ -60,38 +61,96 @@
      (hyperlink next-page next-page (< curr-page last-page) false)
      (hyperlink last-page (hiccup-util/escape-html ">>") (not single-page?) (= curr-page last-page))]))
 
-(defn confirmation-dialog [{:keys [prefix-route queue]}]
+(defn- confirmation-dialog [{:keys [prefix-route queue]}]
   [:dialog {:class "purge-dialog"}
    [:div "Are you sure, you want to purge the " [:span.highlight queue] " queue?"]
    [:form {:action (prefix-route "/enqueued/queue/" queue)
            :method "post"
            :class  "dialog-btns"}
     [:input {:name "_method" :type "hidden" :value "delete"}]
-    [:input {:name "queue" :value queue :type "hidden"}]
     [:input {:type "button" :value "Cancel" :class "btn btn-md btn-cancel cancel"}]
     [:input {:type "submit" :value "Confirm" :class "btn btn-danger btn-md"}]]])
 
-(defn- enqueued-page-view [{:keys [jobs total-jobs] :as data}]
+(defn- sticky-header [{:keys                                    [prefix-route queue]
+                       {:keys [filter-type filter-value limit]} :params}]
+  [:div.header
+   [:form.filter-opts {:action (prefix-route "/enqueued/queue/" queue)
+                       :method "get"}
+    [:div.filter-opts-items
+     [:select {:name "filter-type" :class "filter-type"}
+      (for [type ["id" "execute-fn-sym" "type"]]
+        [:option {:value type :selected (= type filter-type)} type])]
+     [:div.filter-values
+
+      ;; filter-value element is dynamically changed in JavaScript based on filter-type
+      ;; Any attribute update in field-value should be reflected in JavaScript file too
+
+      (if (= filter-type "type")
+        [:select {:name "filter-value" :class "filter-value"}
+         (for [val ["unexecuted" "failed"]]
+           [:option {:value val :selected (= val filter-value)} val])]
+        [:input {:name  "filter-value" :type "text" :placeholder "filter value"
+                 :class "filter-value" :value filter-value}])]]
+    [:div.filter-opts-items
+     [:span.limit "Limit"]
+     [:input {:type  "number" :name "limit" :id "limit" :placeholder "custom limit"
+              :value (if (string/blank? limit) d/limit limit)
+              :max   "10000"}]]
+    [:div.filter-opts-items
+     [:button.btn.btn-cancel
+      [:a. {:href (prefix-route "/enqueued/queue/" queue) :class "cursor-default"} "Clear"]]
+     [:button.btn {:type "submit"} "Apply"]]]])
+
+(defn- jobs-page-view [{:keys [jobs total-jobs] :as data}]
   [:div.redis-enqueued-main-content
    [:h1 "Enqueued Jobs"]
    [:div.content
     (sidebar data)
     [:div.right-side
+     (sticky-header data)
      [:div.pagination
-      (pagination data)]
+      (when total-jobs
+        (pagination data))]
      (enqueued-jobs-table jobs)
-     (when (> total-jobs 0)
+     (when (and total-jobs (> total-jobs 0))
        [:div.bottom
         (confirmation-dialog data)
         [:button {:class "btn btn-danger btn-lg purge-dialog-show"} "Purge"]])]]])
 
-(defn page [{:keys                     [prefix-route]
-             {:keys [app-name broker]} :console-opts
-             {:keys [page]}            :params
-             {:keys [queue]}           :route-params}]
-  (let [view (c/layout c/header enqueued-page-view)
-        data (data/enqueued-page-data (:redis-conn broker) queue page)]
-    (response/response (view "Enqueued" (assoc data :app-name app-name
+(defn validate-get-jobs [{:keys [page filter-type limit filter-value queue]}]
+  (let [page (specs/validate-or-default ::specs/page
+                                        (specs/str->long page)
+                                        (specs/str->long page)
+                                        d/page)
+        queue (specs/validate-or-default ::specs/queue queue)
+        f-type (specs/validate-or-default ::specs/filter-type filter-type)
+        f-val (case f-type
+                "id" (specs/validate-or-default ::specs/filter-value-id
+                                                (parse-uuid filter-value)
+                                                filter-value)
+                "execute-fn-sym" (specs/validate-or-default ::specs/filter-value-sym
+                                                            filter-value)
+                "type" (specs/validate-or-default ::specs/filter-value-type
+                                                  filter-value)
+                nil)
+        limit (specs/validate-or-default ::specs/limit
+                                         (specs/str->long limit)
+                                         (specs/str->long limit)
+                                         d/limit)]
+    {:page         page
+     :queue        queue
+     :filter-type  f-type
+     :filter-value f-val
+     :limit        limit}))
+
+(defn get-jobs [{:keys                     [prefix-route]
+                 {:keys [app-name broker]} :console-opts
+                 params                    :params}]
+  (let [view (c/layout c/header jobs-page-view)
+        validated-params (validate-get-jobs params)
+        data (data/enqueued-page-data (:redis-conn broker) validated-params)]
+    (response/response (view "Enqueued" (assoc data :params params
+                                                    :app-name app-name
                                                     :prefix-route prefix-route)))))
 
 (defn purge-queue [{{:keys [broker]} :console-opts

--- a/src/goose/brokers/redis/console/specs.clj
+++ b/src/goose/brokers/redis/console/specs.clj
@@ -4,6 +4,13 @@
     (java.lang Long)))
 
 (s/def ::page (s/and pos-int?))
+(s/def ::queue (s/and string?))
+
+(s/def ::filter-type #{"id" "execute-fn-sym" "type"})
+(s/def ::filter-value-id uuid?)
+(s/def ::filter-value-sym string?)
+(s/def ::filter-value-type #{"unexecuted" "failed"})
+(s/def ::limit nat-int?)
 
 (defn str->long
   [str]
@@ -11,3 +18,11 @@
     str
     (try (Long/parseLong str)
          (catch Exception _ :clojure.spec.alpha/invalid))))
+
+(defn validate-or-default
+  ([spec ip] (validate-or-default spec ip ip))
+  ([spec ip op] (validate-or-default spec ip op nil))
+  ([spec ip op default]
+   (if (s/valid? spec ip)
+     op
+     default)))

--- a/src/goose/defaults.clj
+++ b/src/goose/defaults.clj
@@ -80,3 +80,4 @@
 
 (def page-size 10)
 (def page 1)
+(def limit 10)

--- a/test/goose/brokers/redis/console/data_test.clj
+++ b/test/goose/brokers/redis/console/data_test.clj
@@ -1,9 +1,12 @@
 (ns goose.brokers.redis.console.data-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [goose.brokers.redis.api.enqueued-jobs :as enqueued-jobs]
             [goose.brokers.redis.console.data :as console]
             [goose.defaults :as d]
             [goose.factories :as f]
             [goose.test-utils :as tu]))
+
+(use-fixtures :each tu/redis-fixture)
 
 (deftest jobs-size-test
   (testing "Should return job size for enqueued, scheduled, periodic and dead jobs"
@@ -20,33 +23,85 @@
     (is (= (console/jobs-size tu/redis-conn) {:enqueued 3 :scheduled 3 :periodic 1 :dead 1}))))
 
 (deftest enqueued-page-data-test
-  (testing "Should get enqueued-jobs page data i.e :total-jobs, total-jobs count, all queues, current queue and page"
+  (testing "Should get enqueued-jobs page data i.e all jobs, total-jobs count, all queues, current queue and page"
     (f/create-jobs {:enqueued 2})
-    (let [{:keys [queues page queue jobs total-jobs]} (console/enqueued-page-data tu/redis-conn tu/queue "1")]
+    (let [{:keys [queues page queue jobs total-jobs]} (console/enqueued-page-data tu/redis-conn {:queue tu/queue
+                                                                                                 :page  1})]
       (is (= [tu/queue] queues))
       (is (= 1 page))
       (is (= tu/queue queue))
       (is (= 2 (count jobs)))
       (is (= 2 total-jobs))))
-  (testing "Should default page value to 1 given no page value"
-    (is (= 1 (:page (console/enqueued-page-data tu/redis-conn tu/queue nil)))))
   (tu/clear-redis)
-  (testing "Should get at-max page-size jobs given >page-size jobs in redis"
+  (testing "Should get at-max page-size jobs given > page-size jobs in redis"
     (f/create-jobs {:enqueued 8})
     (with-redefs [d/page-size 3]
-      (let [{:keys [page jobs total-jobs]} (console/enqueued-page-data tu/redis-conn tu/queue "2")]
+      (let [{:keys [page jobs total-jobs]} (console/enqueued-page-data tu/redis-conn {:queue tu/queue
+                                                                                      :page  2})]
         (is (= 2 page))
         (is (= 3 (count jobs)))
         (is (= 8 total-jobs)))
-      (is (= 2 (-> (console/enqueued-page-data tu/redis-conn tu/queue "3") (get :jobs) count)))))
+      (is (= 2 (-> (console/enqueued-page-data tu/redis-conn {:queue tu/queue
+                                                              :page  3}) (get :jobs) count)))))
   (tu/clear-redis)
   (testing "Should get name of all the queues"
     (f/create-async-job)
     (f/create-async-job {:queue       "queue1"
                          :ready-queue "goose/queue:queue1"})
-    (is (true? (every? #{tu/queue "queue1"} (-> (console/enqueued-page-data tu/redis-conn tu/queue nil) (get :queues))))))
+    (is (every? #{tu/queue "queue1"} (-> (console/enqueued-page-data tu/redis-conn {:queue tu/queue
+                                                                                    :page  1})
+                                         (get :queues)))))
   (tu/clear-redis)
   (testing "Should get no jobs data given no jobs exist in redis"
-    (let [{:keys [jobs total-jobs]} (console/enqueued-page-data tu/redis-conn tu/queue nil)]
+    (let [{:keys [jobs total-jobs]} (console/enqueued-page-data tu/redis-conn {:queue tu/queue
+                                                                               :page  1})]
       (is (= [] jobs))
-      (is (= 0 total-jobs)))))
+      (is (= 0 total-jobs))))
+  (tu/clear-redis)
+  (testing "Should filter the jobs by id, execute-fn-symbol and type, given valid filter-params"
+    (f/create-jobs {:enqueued 3})
+    (f/create-jobs {:enqueued 4} {:enqueued {:execute-fn-sym `prn}})
+    (f/create-jobs {:enqueued 2} {:enqueued {:state {:error           "Error"
+                                                     :last-retried-at 1701344365468,
+                                                     :first-failed-at 1701344365468,
+                                                     :retry-count     2,
+                                                     :retry-at        1701344433359}}})
+    (let [job1 (-> (enqueued-jobs/get-by-range tu/redis-conn tu/queue 1 10) first)
+          base-params {:queue  tu/queue
+                       :queues (list tu/queue)
+                       :page   1
+                       :limit  10}]
+      (is (= {:page   1
+              :queue  tu/queue
+              :queues (list tu/queue)
+              :jobs   [job1]} (console/enqueued-page-data tu/redis-conn (merge base-params {:filter-type  "id"
+                                                                                            :filter-value (:id job1)}))))
+      (is (= 4 (-> (console/enqueued-page-data tu/redis-conn (merge base-params {:filter-type  "execute-fn-sym"
+                                                                                 :filter-value "clojure.core/prn"}))
+                   :jobs count)))
+      (is (= 2 (-> (console/enqueued-page-data tu/redis-conn (merge base-params {:filter-type  "type"
+                                                                                 :filter-value "failed"}))
+                   :jobs count)))
+      (is (= 7 (-> (console/enqueued-page-data tu/redis-conn (merge base-params {:filter-type  "type"
+                                                                                 :filter-value "unexecuted"}))
+                   :jobs count)))))
+  (tu/clear-redis)
+  (testing "Should not return jobs given invalid params"
+    (f/create-jobs {:enqueued 1})
+    (is (= {:queue  tu/queue
+            :page   1
+            :queues (list tu/queue)} (console/enqueued-page-data tu/redis-conn {:queue        tu/queue
+                                                                                :page         1
+                                                                                :filter-type  "id"
+                                                                                :filter-value nil
+                                                                                :limit        10}))))
+  (tu/clear-redis)
+  (testing "Should return all the jobs given no filter params"
+    (f/create-jobs {:enqueued 2})
+    (let [jobs (enqueued-jobs/get-by-range tu/redis-conn tu/queue 0 2)]
+      (is (= {:queue      tu/queue
+              :page       1
+              :queues     (list tu/queue)
+              :total-jobs 2
+              :jobs       jobs} (console/enqueued-page-data tu/redis-conn {:queue tu/queue
+                                                                           :page  1}))))))


### PR DESCRIPTION
Enqueued jobs will be filtered based on different filter type (`id`, `execute-fn-sym`, `type`)

Sample preview:
<img width="1195" alt="image" src="https://github.com/nilenso/goose/assets/36623306/9442645e-f181-4584-a93f-a625eeb6ba26">

