### PR TITLE
Rabbitmq's console homepage page

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -16,8 +16,7 @@
                         :extra-deps  {io.github.cognitect-labs/test-runner {:git/tag "v0.5.0" :git/sha "b3fd0d2"}
                                       cnuernber/dtype-next                 {:mvn/version "10.102"}
                                       ring/ring-mock                       {:mvn/version "0.3.2"}
-                                      tortue/spy                           {:mvn/version "2.14.0"} 
-                                      org.clj-commons/hickory              {:mvn/version "0.7.4"}}
+                                      tortue/spy                           {:mvn/version "2.14.0"}}
                         :exec-fn     test-runner/test-and-shutdown}
            :repl       {:extra-deps {vvvvalvalval/scope-capture  {:mvn/version "0.3.2"}
                                      org.clojure/tools.namespace {:mvn/version "1.3.0"}}}

--- a/src/goose/brokers/redis/console.clj
+++ b/src/goose/brokers/redis/console.clj
@@ -2,31 +2,10 @@
   (:require [bidi.bidi :as bidi]
             [goose.brokers.redis.console.pages.enqueued :as enqueued]
             [goose.brokers.redis.console.pages.home :as home]
-            [ring.util.response :as response]))
-
-(defn- load-css [_]
-  (-> "css/style.css"
-      response/resource-response
-      (response/header "Content-Type" "text/css")))
-
-(defn- load-img [_]
-  (-> "img/goose-logo.png"
-      response/resource-response
-      (response/header "Content-Type" "image/png")))
-
-(defn- load-js [_]
-  (-> "js/index.js"
-      response/resource-response
-      (response/header "Content-Type" "text/javascript")))
-
-(defn- redirect-to-home-page [{:keys [prefix-route]}]
-  (response/redirect (prefix-route "/")))
-
-(defn- not-found [_]
-  (response/not-found "<div> Not found </div>"))
+            [goose.console :as console]))
 
 (defn routes [route-prefix]
-  [route-prefix [["" redirect-to-home-page]
+  [route-prefix [["" console/redirect-to-home-page]
                  ["/" home/page]
                  ["/enqueued" {""                 enqueued/get-jobs
                                ["/queue/" :queue] [[:get enqueued/get-jobs]
@@ -36,10 +15,10 @@
                                                    [["/job/" :id] [[:get enqueued/get-job]
                                                                    [:post enqueued/prioritise-job]
                                                                    [:delete enqueued/delete-job]]]]}]
-                 ["/css/style.css" load-css]
-                 ["/img/goose-logo.png" load-img]
-                 ["/js/index.js" load-js]
-                 [true not-found]]])
+                 ["/css/style.css" console/load-css]
+                 ["/img/goose-logo.png" console/load-img]
+                 ["/js/index.js" console/load-js]
+                 [true console/not-found]]])
 
 (defn handler [_ {:keys                                        [uri request-method]
                   {:keys [route-prefix] :or {route-prefix ""}} :console-opts

--- a/src/goose/brokers/redis/console.clj
+++ b/src/goose/brokers/redis/console.clj
@@ -1,4 +1,4 @@
-(ns goose.brokers.redis.console
+(ns ^:no-doc goose.brokers.redis.console
   (:require [bidi.bidi :as bidi]
             [goose.brokers.redis.console.pages.enqueued :as enqueued]
             [goose.brokers.redis.console.pages.home :as home]

--- a/src/goose/brokers/redis/console/data.clj
+++ b/src/goose/brokers/redis/console/data.clj
@@ -1,4 +1,4 @@
-(ns goose.brokers.redis.console.data
+(ns ^:no-doc goose.brokers.redis.console.data
   (:require [goose.brokers.redis.api.dead-jobs :as dead-jobs]
             [goose.brokers.redis.api.enqueued-jobs :as enqueued-jobs]
             [goose.brokers.redis.api.scheduled-jobs :as scheduled-jobs]

--- a/src/goose/brokers/redis/console/pages/components.clj
+++ b/src/goose/brokers/redis/console/pages/components.clj
@@ -1,7 +1,7 @@
 (ns goose.brokers.redis.console.pages.components
   (:require [clojure.string :as str]
-            [goose.job :as job]
-            [hiccup.page :refer [html5 include-css include-js]])
+            [goose.console :as console]
+            [goose.job :as job])
   (:import
     (java.lang Character String)
     (java.util Date)))
@@ -13,33 +13,8 @@
     Character (str "\\" arg)
     arg))
 
-(defn layout [& components]
-  (fn [title {:keys [prefix-route] :as data}]
-    (html5 {:lang "en"}
-           [:head
-            [:meta {:charset "UTF-8"}]
-            [:meta {:name "viewport" :content "width=device-width, initial-scale=1.0"}]
-            [:title title]
-            (include-css (prefix-route "/css/style.css"))
-            (include-js (prefix-route "/js/index.js"))]
-           [:body
-            (map (fn [c] (c data)) components)])))
-
-(defn header [{:keys [app-name prefix-route uri] :or {app-name ""}}]
-  (let [subroute? (fn [r] (str/includes? uri (prefix-route r)))
-        short-app-name (if (> (count app-name) 20)
-                         (str (subs app-name 0 17) "..")
-                         app-name)]
-    [:header
-     [:nav
-      [:div.nav-start
-       [:div.goose-logo
-        [:a {:href ""}
-         [:img {:src (prefix-route "/img/goose-logo.png") :alt "goose-logo"}]]]
-       [:div#menu
-        [:a {:href (prefix-route "/") :class "app-name"} short-app-name]
-        [:a {:href (prefix-route "/enqueued")
-             :class (when (subroute? "/enqueued") "highlight")} "Enqueued"]]]]]))
+(def header
+  (partial console/header [{:route "/enqueued" :label "Enqueued"}]))
 
 (defn delete-confirm-dialog [question]
   [:dialog {:class "delete-dialog"}

--- a/src/goose/brokers/redis/console/pages/components.clj
+++ b/src/goose/brokers/redis/console/pages/components.clj
@@ -43,7 +43,7 @@
                   :as                       job}]
   [:table.job-table.table-stripped
    [:tr [:td "Id"]
-    [:td.blue id]]
+    [:td id]]
    [:tr [:td "Execute fn symbol"]
     [:td.execute-fn-sym
      (str execute-fn-sym)]]

--- a/src/goose/brokers/redis/console/pages/components.clj
+++ b/src/goose/brokers/redis/console/pages/components.clj
@@ -1,4 +1,4 @@
-(ns goose.brokers.redis.console.pages.components
+(ns ^:no-doc goose.brokers.redis.console.pages.components
   (:require [clojure.string :as str]
             [goose.console :as console]
             [goose.job :as job])

--- a/src/goose/brokers/redis/console/pages/enqueued.clj
+++ b/src/goose/brokers/redis/console/pages/enqueued.clj
@@ -81,6 +81,7 @@
      [:span.limit "Limit"]
      [:input {:type  "number" :name "limit" :id "limit" :placeholder "custom limit"
               :value (if (string/blank? limit) d/limit limit)
+              :min   "0"
               :max   "10000"}]]
     [:div.filter-opts-items
      [:button.btn.btn-cancel

--- a/src/goose/brokers/redis/console/pages/enqueued.clj
+++ b/src/goose/brokers/redis/console/pages/enqueued.clj
@@ -1,4 +1,4 @@
-(ns goose.brokers.redis.console.pages.enqueued
+(ns ^:no-doc goose.brokers.redis.console.pages.enqueued
   (:require [clojure.string :as string]
             [goose.brokers.redis.api.enqueued-jobs :as enqueued-jobs]
             [goose.brokers.redis.console.data :as data]

--- a/src/goose/brokers/redis/console/pages/enqueued.clj
+++ b/src/goose/brokers/redis/console/pages/enqueued.clj
@@ -4,6 +4,7 @@
             [goose.brokers.redis.console.data :as data]
             [goose.brokers.redis.console.pages.components :as c]
             [goose.brokers.redis.console.specs :as specs]
+            [goose.console :as console]
             [goose.defaults :as d]
             [goose.utils :as utils]
             [hiccup.util :as hiccup-util]
@@ -185,7 +186,7 @@
                 {:keys                [app-name]
                  {:keys [redis-conn]} :broker} :console-opts
                 params                         :params}]
-  (let [view (c/layout c/header job-page-view)
+  (let [view (console/layout c/header job-page-view)
         {:keys [id queue]} (validate-req-params params)]
     (if id
       (response/response (view "Enqueued" (-> {:job (enqueued-jobs/find-by-id
@@ -201,7 +202,7 @@
 (defn get-jobs [{:keys                     [prefix-route uri]
                  {:keys [app-name broker]} :console-opts
                  params                    :params}]
-  (let [view (c/layout c/header jobs-page-view)
+  (let [view (console/layout c/header jobs-page-view)
         validated-params (validate-get-jobs params)
         data (data/enqueued-page-data (:redis-conn broker) validated-params)]
     (response/response (view "Enqueued" (assoc data :uri uri

--- a/src/goose/brokers/redis/console/pages/home.clj
+++ b/src/goose/brokers/redis/console/pages/home.clj
@@ -1,5 +1,6 @@
 (ns goose.brokers.redis.console.pages.home
   (:require [goose.brokers.redis.console.data :as data]
+            [goose.console :as console]
             [goose.brokers.redis.console.pages.components :as c]
             [ring.util.response :as response]))
 
@@ -17,7 +18,7 @@
 
 (defn page [{:keys                     [prefix-route uri]
              {:keys [app-name broker]} :console-opts}]
-  (let [view (c/layout c/header stats-bar)
+  (let [view (console/layout c/header stats-bar)
         data (data/jobs-size (:redis-conn broker))]
     (response/response (view "Home" (assoc data :uri uri
                                                 :app-name app-name

--- a/src/goose/brokers/redis/console/pages/home.clj
+++ b/src/goose/brokers/redis/console/pages/home.clj
@@ -1,4 +1,4 @@
-(ns goose.brokers.redis.console.pages.home
+(ns ^:no-doc goose.brokers.redis.console.pages.home
   (:require [goose.brokers.redis.console.data :as data]
             [goose.brokers.redis.console.pages.components :as c]
             [goose.console :as console]

--- a/src/goose/brokers/redis/console/pages/home.clj
+++ b/src/goose/brokers/redis/console/pages/home.clj
@@ -1,16 +1,16 @@
 (ns goose.brokers.redis.console.pages.home
   (:require [goose.brokers.redis.console.data :as data]
-            [goose.console :as console]
             [goose.brokers.redis.console.pages.components :as c]
+            [goose.console :as console]
             [ring.util.response :as response]))
 
 (defn- stats-bar [{:keys [prefix-route] :as page-data}]
   [:main
    [:section.statistics
     (for [{:keys [id label route]} [{:id :enqueued :label "Enqueued" :route "/enqueued"}
-                                    {:id :scheduled :label "Scheduled" :route "/scheduled"}
-                                    {:id :periodic :label "Periodic" :route "/periodic"}
-                                    {:id :dead :label "Dead" :route "/dead"}]]
+                                    {:id :scheduled :label "Scheduled" :route "/"} ;; Routed to homepage since pages are non-existent
+                                    {:id :periodic :label "Periodic" :route "/"}
+                                    {:id :dead :label "Dead" :route "/"}]]
       [:div.stat {:id id}
        [:span.number (str (get page-data id))]
        [:a {:href (prefix-route route)}

--- a/src/goose/brokers/redis/console/specs.clj
+++ b/src/goose/brokers/redis/console/specs.clj
@@ -1,4 +1,4 @@
-(ns goose.brokers.redis.console.specs
+(ns ^:no-doc goose.brokers.redis.console.specs
   (:require [clojure.spec.alpha :as s])
   (:import
     (java.lang Long)))

--- a/src/goose/brokers/rmq/broker.clj
+++ b/src/goose/brokers/rmq/broker.clj
@@ -11,6 +11,7 @@
     [goose.brokers.rmq.scheduler :as rmq-scheduler]
     [goose.brokers.rmq.shutdown-listener :as shutdown-listener]
     [goose.brokers.rmq.worker :as rmq-worker]
+    [goose.brokers.rmq.console :as console]
     [goose.defaults :as d]
     [goose.job :as job]
     [goose.specs :as specs]
@@ -60,6 +61,9 @@
                              n))
   (dead-jobs-purge [this]
     (dead-jobs/purge (u/random-element (:channels this))))
+
+  (handler [this req]
+    (console/handler this req))
 
   Close
   (close [this]

--- a/src/goose/brokers/rmq/commands.clj
+++ b/src/goose/brokers/rmq/commands.clj
@@ -72,13 +72,13 @@
     (async-enqueue ch exch queue job properties)))
 
 (defn enqueue-back
-  ([ch queue-opts publisher-confirms job]
-   (enqueue ch
-            d/rmq-exchange queue-opts
-            publisher-confirms
-            job
-            {:mandatory true
-             :priority  d/rmq-low-priority})))
+  [ch queue-opts publisher-confirms job]
+  (enqueue ch
+           d/rmq-exchange queue-opts
+           publisher-confirms
+           job
+           {:mandatory true
+            :priority  d/rmq-low-priority}))
 
 (defn enqueue-front
   [ch queue-opts publisher-confirms job]

--- a/src/goose/brokers/rmq/console.clj
+++ b/src/goose/brokers/rmq/console.clj
@@ -1,0 +1,56 @@
+(ns goose.brokers.rmq.console
+  (:require [bidi.bidi :as bidi]
+            [goose.brokers.rmq.api.dead-jobs :as dead-jobs]
+            [goose.brokers.rmq.queue :as rmq-queue]
+            [goose.console :as console]
+            [goose.defaults :as d]
+            [goose.utils :as u]
+            [ring.util.response :as response]))
+
+(def header (partial console/header []))
+
+(defn- stats-bar [{:keys [prefix-route] :as page-data}]
+  [:main
+   [:section.statistics
+    (for [{:keys [id label route]} [{:id :dead :label "Dead" :route "/dead"}]]
+      [:div.stat {:id id}
+       [:span.number (str (get page-data id))]
+       [:a {:href (prefix-route route)}
+        [:span.label label]]])]])
+
+(defn declare-dead-queue
+  [rmq-producer]
+  (let [ch (u/random-element (:channels rmq-producer))]
+    (rmq-queue/declare ch (merge (:queue-type rmq-producer)
+                                 {:queue d/prefixed-dead-queue}))))
+
+(defn homepage [{:keys                     [prefix-route uri]
+                 {:keys [app-name broker]} :console-opts}]
+  (let [view (console/layout header stats-bar)
+        _ (declare-dead-queue broker)                       ;; Declare dead-jobs queue to prevent rmq throwing exception
+        data {:dead (dead-jobs/size (u/random-element (:channels broker)))}]
+    (response/response (view "Home" (assoc data :uri uri
+                                                :app-name app-name
+                                                :prefix-route prefix-route)))))
+
+(defn routes [route-prefix]
+  [route-prefix [["" console/redirect-to-home-page]
+                 ["/" homepage]
+                 ["/css/style.css" console/load-css]
+                 ["/img/goose-logo.png" console/load-img]
+                 ["/js/index.js" console/load-js]
+                 [true console/not-found]]])
+
+(defn handler [_ {:keys                                        [uri request-method]
+                  {:keys [route-prefix] :or {route-prefix ""}} :console-opts
+                  :as                                          req}]
+  (let [{page-handler :handler
+         route-params :route-params} (-> route-prefix
+                                         routes
+                                         (bidi/match-route
+                                           uri
+                                           {:request-method
+                                            request-method}))]
+    (-> req
+        (update :params merge route-params)
+        page-handler)))

--- a/src/goose/brokers/rmq/console.clj
+++ b/src/goose/brokers/rmq/console.clj
@@ -18,7 +18,7 @@
        [:a {:href (prefix-route route)}
         [:span.label label]]])]])
 
-(defn declare-dead-queue
+(defn- declare-dead-queue
   [rmq-producer]
   (let [ch (u/random-element (:channels rmq-producer))]
     (rmq-queue/declare ch (merge (:queue-type rmq-producer)
@@ -33,7 +33,7 @@
                                                 :app-name app-name
                                                 :prefix-route prefix-route)))))
 
-(defn routes [route-prefix]
+(defn- routes [route-prefix]
   [route-prefix [["" console/redirect-to-home-page]
                  ["/" homepage]
                  ["/css/style.css" console/load-css]

--- a/src/goose/brokers/rmq/console.clj
+++ b/src/goose/brokers/rmq/console.clj
@@ -1,4 +1,4 @@
-(ns goose.brokers.rmq.console
+(ns ^:no-doc goose.brokers.rmq.console
   (:require [bidi.bidi :as bidi]
             [goose.brokers.rmq.api.dead-jobs :as dead-jobs]
             [goose.brokers.rmq.queue :as rmq-queue]

--- a/src/goose/console.clj
+++ b/src/goose/console.clj
@@ -8,7 +8,7 @@
 
 ;; Page handlers
 (defn load-css
-  "Load static goose's css file"
+  "Load static css file"
   [_]
   (-> "css/style.css"
       response/resource-response
@@ -22,7 +22,7 @@
       (response/header "Content-Type" "image/png")))
 
 (defn load-js
-  "Load a goose's javascript file"
+  "Load javascript file"
   [_]
   (-> "js/index.js"
       response/resource-response
@@ -113,7 +113,20 @@
       (handler (assoc request :request-method (keyword overridden-method)))
       (handler request))))
 
-(defn app-handler [{:keys [broker] :as console-opts} req]
+(defn app-handler
+  "A Ring handler that sets up the necessary middleware and serves Goose Console UI
+  It takes two arguments:
+
+  ### Keys
+  `:console-opts`    : A map containing the configuration options for the console \\
+     `:route-prefix` : The route path that exposes the Goose Console via app-handler (should not include a trailing \"/\") \\
+     `:broker`       : Message broker that transfers message from Producer to Consumer.
+                       Given value must implement [[goose.broker/Broker]] protocol.
+                       [Message Broker wiki](https://github.com/nilenso/goose/wiki/Message-Brokers)
+     `:app-name`     : Name of the application using Goose
+
+   `:req`               : The Ring request map representing the incoming HTTP request."
+  [{:keys [broker] :as console-opts} req]
   ((-> (partial b/handler broker)
        wrap-prefix-route
        wrap-method-override

--- a/src/goose/console.clj
+++ b/src/goose/console.clj
@@ -1,10 +1,10 @@
 (ns goose.console
-  (:require [goose.broker :as b]
+  (:require [clojure.string :as str]
+            [goose.broker :as b]
+            [hiccup.page :refer [html5 include-css include-js]]
             [ring.middleware.keyword-params :as ring-keyword-params]
             [ring.middleware.params :as ring-params]
-            [ring.util.response :as response]
-            [clojure.string :as str]
-            [hiccup.page :refer [html5 include-css include-js]]))
+            [ring.util.response :as response]))
 
 ;; Page handlers
 (defn load-css
@@ -91,8 +91,8 @@
          [:img {:src (prefix-route "/img/goose-logo.png") :alt "goose-logo"}]]]
        [:div#menu
         [:a {:href (prefix-route "/") :class "app-name"} short-app-name]
-        (for [{:keys [route label]}  header-items]
-          [:a {:href (prefix-route route)
+        (for [{:keys [route label]} header-items]
+          [:a {:href  (prefix-route route)
                :class (when (subroute? route) "highlight")} label])]]]]))
 
 (defn wrap-prefix-route
@@ -100,7 +100,7 @@
   that facilitates URL construction in views by prepending given route-prefix to paths"
   [handler]
   (fn [{{:keys [route-prefix]} :console-opts
-        :as req}]
+        :as                    req}]
     (let [prefix-route-fn (partial str route-prefix)]
       (handler (assoc req :prefix-route prefix-route-fn)))))
 

--- a/test/goose/brokers/rmq/console_test.clj
+++ b/test/goose/brokers/rmq/console_test.clj
@@ -1,0 +1,23 @@
+(ns goose.brokers.rmq.console-test
+  (:require
+    [clojure.string :as str]
+    [clojure.test :refer [deftest is testing]]
+    [goose.brokers.rmq.console :as console]
+    [goose.test-utils :as tu]
+    [ring.mock.request :as mock]
+    [spy.core :as spy]))
+
+(deftest get-homepage-test
+  (testing "Should show rmq's home page even if no jobs in dead queue"
+    (let [response (console/homepage {:console-opts tu/rmq-console-opts
+                                      :prefix-route str})]
+      (is (= 200 (:status response)))
+      (is (str/starts-with? (:body response) "<!DOCTYPE html>")))))
+
+(deftest page-handler-test
+  (testing "Handler should invoke homepage handler"
+    (with-redefs [console/homepage (spy/stub {:status 200 :body "Mocked resp"})]
+      (console/handler tu/rmq-producer (mock/request :get
+                                                     "/"))
+      (true? (spy/called-once? console/homepage))
+      (is (= [{:status 200 :body "Mocked resp"}] (spy/responses console/homepage))))))

--- a/test/goose/test_utils.clj
+++ b/test/goose/test_utils.clj
@@ -77,6 +77,11 @@
 (def rmq-consumer (rmq/new-consumer rmq-opts))
 (def rmq-client-opts (assoc client-opts :broker rmq-producer))
 (def rmq-worker-opts (assoc worker-opts :broker rmq-consumer))
+
+(def rmq-console-opts {:broker rmq-producer
+                       :app-name     ""
+                       :route-prefix "" })
+
 (defn rmq-delete-test-queues
   []
   (let [ch (u/random-element (:channels rmq-producer))]


### PR DESCRIPTION
Rabbitmq console homepage. 🥹
The PR adds following changes:
- Move app handlers and view components (common to both brokers) to `goose.console` namespace
- Add rmq's console handler to
  - view landing page (size of dead jobs, since rmq api only allows dead job's size)
  
Note: RabbitMQ queues are only created when jobs are being enqueued. If a req is sent to console before queue is created, RabbitMQ will throw an exception and close the channel. To prevent this scenario, the console declares  dead-queue if it has not already been registered.

<img width="1401" alt="image" src="https://github.com/nilenso/goose/assets/36623306/f0857011-8766-4ddc-8d1d-496bb547f797">
