### PR TITLE
Replace ceilDiv with clojure.math/ceil

### DIFF
--- a/src/goose/brokers/redis/console/pages/enqueued.clj
+++ b/src/goose/brokers/redis/console/pages/enqueued.clj
@@ -1,5 +1,6 @@
 (ns ^:no-doc goose.brokers.redis.console.pages.enqueued
   (:require [clojure.string :as string]
+    [clojure.math :as math]
             [goose.brokers.redis.api.enqueued-jobs :as enqueued-jobs]
             [goose.brokers.redis.console.data :as data]
             [goose.brokers.redis.console.pages.components :as c]
@@ -10,7 +11,6 @@
             [hiccup.util :as hiccup-util]
             [ring.util.response :as response])
   (:import
-    (java.lang Math)
     (java.util Date)))
 
 (defn- sidebar [{:keys [prefix-route queues queue]}]
@@ -33,7 +33,7 @@
 (defn- pagination [{:keys [prefix-route queue page total-jobs]}]
   (let [{:keys [first-page prev-page curr-page
                 next-page last-page]} (pagination-stats d/page page
-                                                        (Math/ceilDiv ^Integer total-jobs ^Integer d/page-size))
+                                                        (math/ceil (/ total-jobs d/page-size)))
         page-uri (fn [p] (prefix-route "/enqueued/queue/" queue "?page=" p))
         hyperlink (fn [page label visible? disabled? & class]
                     (when visible?

--- a/src/goose/brokers/redis/console/pages/enqueued.clj
+++ b/src/goose/brokers/redis/console/pages/enqueued.clj
@@ -1,6 +1,6 @@
 (ns ^:no-doc goose.brokers.redis.console.pages.enqueued
   (:require [clojure.string :as string]
-    [clojure.math :as math]
+            [clojure.math :as math]
             [goose.brokers.redis.api.enqueued-jobs :as enqueued-jobs]
             [goose.brokers.redis.console.data :as data]
             [goose.brokers.redis.console.pages.components :as c]

--- a/src/goose/console.clj
+++ b/src/goose/console.clj
@@ -1,60 +1,63 @@
 (ns goose.console
+  "Functions to serve the console web interface"
   (:require [clojure.string :as str]
             [goose.broker :as b]
+            [goose.defaults :as d]
             [hiccup.page :refer [html5 include-css include-js]]
             [ring.middleware.keyword-params :as ring-keyword-params]
             [ring.middleware.params :as ring-params]
             [ring.util.response :as response]))
 
 ;; Page handlers
-(defn load-css
-  "Load static css file"
+(defn ^:no-doc load-css
+  "Load goose console's static css file"
   [_]
-  (-> "css/style.css"
+  (-> "css/style.css" 
       response/resource-response
       (response/header "Content-Type" "text/css")))
 
-(defn load-img
+(defn ^:no-doc load-img
   "Load goose logo"
   [_]
   (-> "img/goose-logo.png"
       response/resource-response
       (response/header "Content-Type" "image/png")))
 
-(defn load-js
-  "Load javascript file"
+(defn ^:no-doc load-js
+  "Load goose console's javascript file"
   [_]
   (-> "js/index.js"
       response/resource-response
       (response/header "Content-Type" "text/javascript")))
 
-(defn redirect-to-home-page
-  "Redirects the user to the home page using given prefix-route function"
+(defn ^:no-doc redirect-to-home-page
+  "Redirects the user to the homepage"
   [{:keys [prefix-route]}]
   (response/redirect (prefix-route "/")))
 
-(defn not-found
-  "A default not found response"
+(defn ^:no-doc not-found
+  "Default not found response"
   [_]
   (response/not-found "<div> Not found </div>"))
 
 ;; View components
-(defn layout
+(defn ^:no-doc layout
   "Generates HTML layout for webpage using provided hiccup components
 
-  ### Args
+   ### Args
 
-  components: A variadic list of functions. Each function is expected to accept
-              a map `data` and return hiccup data representing part of a webpage
+   components: A variadic list of functions. Each function is expected to accept
+   a map `data` and return hiccup data representing part of a webpage
 
-  ### Usage
-   ```Clojure
-   (def job [job]
-        [:p {:class \"job\"} (:id job)])
+   ### Usage
+   ```clojure
+    (defn job [j]
+      [:div (:id j)])
 
-       (let [view (layout job)]
-          (view \"Jobs page\" {:id \"jid\"})
-   ```"
+   (defn job-page [{:keys [id] :as _req}]
+     (let [view (layout job)]
+       (view \"Jobs page\" {:id id :prefix-route str})))
+       ```"
   [& components]
   (fn [title {:keys [prefix-route] :as data}]
     (html5 {:lang "en"}
@@ -67,18 +70,23 @@
            [:body
             (map (fn [c] (c data)) components)])))
 
-(defn header
-  "Creates a navbar header in hiccup syntax with goose logo and app name
 
-  ### Args
+(defn ^:no-doc header
+  "Creates a navbar header in hiccup syntax consisting of goose logo and app name
+
+   ### Args
+
   `header-items` : A seq of maps each containing route and label keys to
-  specify navigation links
+   specify navigation links \\
 
-  `data` : A map that should include:
-      - `uri`: The current page's URI to identify the active link
-      - `app-name`: Application's name
-      - `prefix-route`: Function to prepend paths for URL generation"
-  [header-items {:keys [app-name prefix-route uri] :or {app-name ""}}]
+   `data` : A map that includes: \\
+
+   - `uri`         : The current page's URI to check to highlight as active link \\
+   - `app-name`    : Application's name \\
+   - `prefix-route`: Function to prepend paths to generate url \\"
+
+  [header-items {:keys [app-name prefix-route uri] :or {app-name ""}
+                 :as   _data}]
   (let [subroute? (fn [r] (str/includes? uri (prefix-route r)))
         short-app-name (if (> (count app-name) 20)
                          (str (subs app-name 0 17) "..")
@@ -95,7 +103,7 @@
           [:a {:href  (prefix-route route)
                :class (when (subroute? route) "highlight")} label])]]]]))
 
-(defn wrap-prefix-route
+(defn ^:no-doc wrap-prefix-route
   "Middleware that injects a `prefix-route` function into the request,
   that facilitates URL construction in views by prepending given route-prefix to paths"
   [handler]
@@ -104,28 +112,45 @@
     (let [prefix-route-fn (partial str route-prefix)]
       (handler (assoc req :prefix-route prefix-route-fn)))))
 
-(defn wrap-method-override
+(defn ^:no-doc wrap-method-override
   "Middleware to override HTTP method based on the `_method` parameters in request params, allowing
-  to simulate PUT, DELETE, PATCH etc. methods that are not supported in HTML forms"
+   to simulate PUT, DELETE, PATCH etc. methods that are not supported in HTML forms"
   [handler]
   (fn [request]
     (if-let [overridden-method (get-in request [:params :_method])]
       (handler (assoc request :request-method (keyword overridden-method)))
       (handler request))))
 
-(defn app-handler
-  "A Ring handler that sets up the necessary middleware and serves Goose Console UI
-  It takes two arguments:
+(def default-console-opts
+  "Map of sample configs for app-handler.
 
   ### Keys
-  `:console-opts`    : A map containing the configuration options for the console \\
-     `:route-prefix` : The route path that exposes the Goose Console via app-handler (should not include a trailing \"/\") \\
-     `:broker`       : Message broker that transfers message from Producer to Consumer.
-                       Given value must implement [[goose.broker/Broker]] protocol.
-                       [Message Broker wiki](https://github.com/nilenso/goose/wiki/Message-Brokers)
-     `:app-name`     : Name of the application using Goose
 
-   `:req`               : The Ring request map representing the incoming HTTP request."
+  `:broker`       : Message broker that transfers message from Producer to Consumer.\\
+   Given value must implement [[goose.broker/Broker]] protocol. \\
+   [Message Broker wiki](https://github.com/nilenso/goose/wiki/Message-Brokers)
+
+  `:route-prefix` : Route path that exposes console via app-handler (should not include a trailing \"/\") \\
+    *Example*     : [[goose.defaults/route-prefix]] \\
+
+  `:app-name`     : Name to be displayed in console navbar \\
+    *Example*     : [[goose.defaults/app-name]] \\"
+  {:route-prefix d/route-prefix
+   :app-name     d/app-name})
+
+(defn app-handler
+  "A Ring handler that sets up the necessary middleware and serves Goose Console. \\
+
+   It takes two arguments: \\
+
+   ### Args
+
+   `:console-opts`   : A map of `:broker`, `:route-prefix`, & `app-name` \\
+    *Example*        : [[default-console-opts]] \\
+
+   `:req`            : Incoming HTTP request \\
+
+   - [Console wiki](https://github.com/nilenso/goose/wiki/Console)"
   [{:keys [broker] :as console-opts} req]
   ((-> (partial b/handler broker)
        wrap-prefix-route

--- a/src/goose/defaults.clj
+++ b/src/goose/defaults.clj
@@ -78,6 +78,8 @@
 
 ;;; ======== Console ========
 
+(def route-prefix "/goose")
+(def app-name "Goose Console")
 (def page-size 10)
 (def page 1)
 (def limit 10)


### PR DESCRIPTION
Fixes #165

Changes involve:
- replace Math/ceilDiv with clojure.math/ceil (supported since Java8)
- format the doc string for [app-handler](https://cljdoc.org/d/com.nilenso/goose/0.5.0/api/goose.console)
- add default-console-opts (Goose philosophy for having sane defaults)
- remove middlewares, view-components and handler functions from cljdocs for now
    - to simplify only viewing necessary apis 
  - above functions will be removed from cljdocs, but will still be available to use