### PR TITLE
Replace periodic with cron

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### [Goose 0.3.0 Project Board](https://github.com/orgs/nilenso/projects/6)
 
 ### Added
-- Periodic jobs for Redis
+- Cron jobs for Redis
 - Pluggable Message Brokers
 - Native support for RabbitMQ
     - Replication, Clustering & Quorum queues

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Features
 - Pluggable [Message Broker](https://github.com/nilenso/goose/wiki/Guide-to-Message-Broker-Integration) & [Metrics Backend](https://github.com/nilenso/goose/wiki/Guide-to-Custom-Metrics-Backend)
 - [Scheduled Jobs](https://github.com/nilenso/goose/wiki/Scheduled-Jobs)
 - [Batch Jobs](https://github.com/nilenso/goose/wiki/Batch-Jobs)
-- [Periodic Jobs](https://github.com/nilenso/goose/wiki/Periodic-Jobs)
+- [Cron Jobs](https://github.com/nilenso/goose/wiki/Cron)
 - [Error Handling & Retries](https://github.com/nilenso/goose/wiki/Error-Handling-&-Retries)
 - [Console](https://github.com/nilenso/goose/wiki/Console)
 - Extensible using [Middlewares](https://github.com/nilenso/goose/wiki/Middlewares)
@@ -76,7 +76,7 @@ com.nilenso/goose {:mvn/version "0.5.2"}
   (w/stop worker) ; Performs graceful shutsdown.
   (rmq/close rmq-consumer))
 ```
-Refer to wiki for [Redis](https://github.com/nilenso/goose/wiki/Redis), [Periodic Jobs](https://github.com/nilenso/goose/wiki/Periodic-Jobs), [Error Handling](https://github.com/nilenso/goose/wiki/Error-Handling-&-Retries), [Monitoring](https://github.com/nilenso/goose/wiki/Monitoring-&-Alerting), [Production Readiness](https://github.com/nilenso/goose/wiki/Production-Readiness), etc.
+Refer to wiki for [Redis](https://github.com/nilenso/goose/wiki/Redis), [Cron](https://github.com/nilenso/goose/wiki/Cron), [Error Handling](https://github.com/nilenso/goose/wiki/Error-Handling-&-Retries), [Monitoring](https://github.com/nilenso/goose/wiki/Monitoring-&-Alerting), [Production Readiness](https://github.com/nilenso/goose/wiki/Production-Readiness), etc.
 
 Getting Help
 ---------

--- a/architecture-decisions/README.md
+++ b/architecture-decisions/README.md
@@ -23,7 +23,7 @@ Index
 1. [Enqueue-Dequeue](https://github.com/nilenso/goose/blob/main/architecture-decisions/pages/enqueue-dequeue.md)
 1. [Priority/Customized Queues](https://github.com/nilenso/goose/blob/main/architecture-decisions/pages/priority-queues.md)
 1. [Scheduled Jobs](https://github.com/nilenso/goose/blob/main/architecture-decisions/pages/scheduled-jobs.md)
-1. [Periodic Jobs](https://github.com/nilenso/goose/blob/main/architecture-decisions/pages/periodic-jobs.md)
+1. [Cron Jobs](https://github.com/nilenso/goose/blob/main/architecture-decisions/pages/periodic-jobs.md)
 1. [Batch Jobs](https://github.com/nilenso/goose/blob/main/architecture-decisions/pages/batch-jobs.md)
 1. [Error-handling & Retrying](https://github.com/nilenso/goose/blob/main/architecture-decisions/pages/error-handling.md)
 1. [API](https://github.com/nilenso/goose/blob/main/architecture-decisions/pages/api.md)

--- a/architecture-decisions/pages/console.md
+++ b/architecture-decisions/pages/console.md
@@ -1,7 +1,7 @@
 ADR: Console
 ============
 
-The Goose Console is a web interface that provides visual representation and control over Goose's job management features for async, scheduled, batch, periodic, and dead jobs.
+The Goose Console is a web interface that provides visual representation and control over Goose's job management features for async, scheduled, batch, cron, and dead jobs.
 
 Design
 -------

--- a/src/goose/api/cron_jobs.clj
+++ b/src/goose/api/cron_jobs.clj
@@ -1,12 +1,12 @@
 (ns goose.api.cron-jobs
-  "API to manage Periodic Jobs AKA Cron Entries.\\
+  "API to manage Cron Entries.\\
   To update a cron entry, call [[goose.client/perform-every]] since it is idempotent.
   - [API wiki](https://github.com/nilenso/goose/wiki/API)"
   (:require
     [goose.broker :as b]))
 
 (defn size
-  "Returns count of Periodic Jobs."
+  "Returns count of Cron entries."
   [broker]
   (b/cron-jobs-size broker))
 

--- a/src/goose/broker.clj
+++ b/src/goose/broker.clj
@@ -43,7 +43,7 @@
   (scheduled-jobs-purge [this] "Purges all the Scheduled Jobs.")
 
   ;; cron jobs API
-  (cron-jobs-size [this] "Returns count of Periodic Jobs.")
+  (cron-jobs-size [this] "Returns count of Cron entries.")
   (cron-jobs-find-by-name [this entry-name] "Finds a Cron Entry by `:name`.")
   (cron-jobs-delete [this entry-name] "Deletes Cron Entry & Cron-Scheduled Job of given `:name`.")
   (cron-jobs-purge [this] "Purges all the Cron Entries & Cron-Scheduled Jobs.")

--- a/src/goose/brokers/redis/console.clj
+++ b/src/goose/brokers/redis/console.clj
@@ -1,10 +1,10 @@
 (ns ^:no-doc goose.brokers.redis.console
   (:require [bidi.bidi :as bidi]
             [goose.brokers.redis.console.pages.batch :as batch]
+            [goose.brokers.redis.console.pages.cron :as cron]
             [goose.brokers.redis.console.pages.dead :as dead]
             [goose.brokers.redis.console.pages.enqueued :as enqueued]
             [goose.brokers.redis.console.pages.home :as home]
-            [goose.brokers.redis.console.pages.periodic :as periodic]
             [goose.brokers.redis.console.pages.scheduled :as scheduled]
             [goose.console :as console]))
 
@@ -35,11 +35,11 @@
                                                [:delete scheduled/delete-job]]}]
                  ["/batch" {""            [[:get batch/get-job]]
                             ["/job/" :id] [[:delete batch/delete-job]]}]
-                 ["/periodic" {""                   [[:get periodic/get-jobs]
-                                                     [:delete periodic/purge-queue]]
-                               "/jobs"              [[:delete periodic/delete-jobs]]
-                               ["/job/" :cron-name] [[:get periodic/get-job]
-                                                     [:delete periodic/delete-job]]}]
+                 ["/cron" {""                   [[:get cron/get-jobs]
+                                                 [:delete cron/purge-queue]]
+                           "/jobs"              [[:delete cron/delete-jobs]]
+                           ["/job/" :cron-name] [[:get cron/get-job]
+                                                 [:delete cron/delete-job]]}]
                  ["/css/style.css" console/load-css]
                  ["/img/goose-logo.png" console/load-img]
                  ["/js/index.js" console/load-js]
@@ -52,9 +52,9 @@
          route-params :route-params} (-> route-prefix
                                          routes
                                          (bidi/match-route
-                                           uri
-                                           {:request-method
-                                            request-method}))]
+                                          uri
+                                          {:request-method
+                                           request-method}))]
     (-> req
         (update :params merge route-params)
         page-handler)))

--- a/src/goose/brokers/redis/console/data.clj
+++ b/src/goose/brokers/redis/console/data.clj
@@ -2,7 +2,7 @@
   (:require [goose.brokers.redis.api.dead-jobs :as dead-jobs]
             [goose.brokers.redis.api.enqueued-jobs :as enqueued-jobs]
             [goose.brokers.redis.api.scheduled-jobs :as scheduled-jobs]
-            [goose.brokers.redis.cron :as periodic-jobs]
+            [goose.brokers.redis.cron :as cron]
             [goose.defaults :as d]
             [goose.job :as job]))
 
@@ -20,11 +20,11 @@
         enqueued (reduce (fn [total queue]
                            (+ total (enqueued-jobs/size redis-conn queue))) 0 queues)
         scheduled (scheduled-jobs/size redis-conn)
-        periodic (periodic-jobs/size redis-conn)
+        cron (cron/size redis-conn)
         dead (dead-jobs/size redis-conn)]
     {:enqueued  enqueued
      :scheduled scheduled
-     :periodic  periodic
+     :cron      cron
      :dead      dead}))
 
 (defn- filter-enqueued-jobs [redis-conn queue {:keys [filter-type filter-value limit]}]
@@ -146,18 +146,18 @@
       (invalid-filter-value? validated-filter-value)
       (assoc base-result :jobs []))))
 
-(defn periodic-page-data
+(defn cron-page-data
   [redis-conn {validated-filter-type  :filter-type
                validated-filter-value :filter-value}]
   (cond
     (filter-jobs-request? validated-filter-type validated-filter-value)
-    {:jobs       (if-let [job (periodic-jobs/find-by-name redis-conn validated-filter-value)]
-                   [job]
-                   [])}
+    {:jobs (if-let [job (cron/find-by-name redis-conn validated-filter-value)]
+             [job]
+             [])}
 
     (get-all-jobs-request? validated-filter-type validated-filter-value)
-    {:total-jobs (periodic-jobs/size redis-conn)
-     :jobs       (periodic-jobs/get-all redis-conn)}
+    {:total-jobs (cron/size redis-conn)
+     :jobs       (cron/get-all redis-conn)}
 
     (invalid-filter-value? validated-filter-value)
     {:jobs []}))

--- a/src/goose/brokers/redis/console/pages/components.clj
+++ b/src/goose/brokers/redis/console/pages/components.clj
@@ -9,7 +9,7 @@
   (partial console/header [{:route "/enqueued" :label "Enqueued" :job-type :enqueued}
                            {:route "/scheduled" :label "Scheduled" :job-type :scheduled}
                            {:route "/batch" :label "Batch" :job-type :batch}
-                           {:route "/periodic" :label "Periodic" :job-type :periodic}
+                           {:route "/cron" :label "Cron" :job-type :cron}
                            {:route "/dead" :label "Dead" :job-type :dead}]))
 
 (defn replay-btn [& {:keys [disabled] :or {disabled true}}]

--- a/src/goose/brokers/redis/console/pages/home.clj
+++ b/src/goose/brokers/redis/console/pages/home.clj
@@ -9,7 +9,7 @@
    [:section.statistics
     (for [{:keys [id label route]} [{:id :enqueued :label "Enqueued" :route "/enqueued"}
                                     {:id :scheduled :label "Scheduled" :route "/scheduled"}
-                                    {:id :periodic :label "Periodic" :route "/periodic"}
+                                    {:id :cron :label "Cron" :route "/cron"}
                                     {:id :dead :label "Dead" :route "/dead"}]]
       [:div.stat {:id id}
        [:span.number (str (get page-data id))]

--- a/src/goose/brokers/redis/console/specs.clj
+++ b/src/goose/brokers/redis/console/specs.clj
@@ -10,7 +10,7 @@
 (s/def ::dead-filter-type #{"id" "execute-fn-sym" "queue"})
 (s/def ::scheduled-filter-type #{"id" "execute-fn-sym" "type" "queue"})
 (s/def ::batch-filter-type #{"id"})
-(s/def ::periodic-filter-type #{"name"})
+(s/def ::cron-filter-type #{"name"})
 
 (s/def ::job-id uuid?)
 (s/def ::cron-name string?)

--- a/src/goose/brokers/redis/metrics.clj
+++ b/src/goose/brokers/redis/metrics.clj
@@ -28,7 +28,7 @@
   [redis-conn]
   {m/schedule-jobs-count (redis-cmds/sorted-set-size redis-conn d/prefixed-schedule-queue)
    m/dead-jobs-count     (redis-cmds/sorted-set-size redis-conn d/prefixed-dead-queue)
-   m/periodic-jobs-count (cron/size redis-conn)})
+   m/cron-count (cron/size redis-conn)})
 
 (defn- batches->count
   [redis-conn]

--- a/src/goose/client.clj
+++ b/src/goose/client.clj
@@ -139,7 +139,7 @@
 
   `cron-opts`      : Map of `:cron-name`, `:cron-schedule`, `:timezone`.
   - `:cron-name` (Mandatory)
-    - Unique identifier of a periodic job
+    - Unique identifier of a cron job
   - `:cron-schedule` (Mandatory)
     - Unix-style schedule
   - `:timezone` (Optional)
@@ -161,7 +161,7 @@
     (perform-every client-opts cron-opts `send-emails \"subject\" \"body\" [:user-1 :user-2]))
   ```
 
-  - [Periodic Jobs wiki](https://github.com/nilenso/goose/wiki/Periodic-Jobs)"
+  - [Cron wiki](https://github.com/nilenso/goose/wiki/Cron)"
   [opts cron-opts execute-fn-sym & args]
   (let [internal-opts (prefix-queues-inside-opts opts)]
     (register-cron-schedule internal-opts cron-opts execute-fn-sym args)))

--- a/src/goose/metrics.clj
+++ b/src/goose/metrics.clj
@@ -28,7 +28,7 @@
   (format "enqueued_jobs.%s.count" (d/affix-queue queue)))
 (defonce ^:no-doc total-enqueued-jobs-count "total_enqueued_jobs.count")
 (defonce ^:no-doc schedule-jobs-count "scheduled_jobs.count")
-(defonce ^:no-doc periodic-jobs-count "periodic_jobs.count")
+(defonce ^:no-doc cron-count "cron.count")
 (defonce ^:no-doc dead-jobs-count "dead_jobs.count")
 (defonce ^:no-doc batches-count "batches.count")
 

--- a/test/goose/brokers/redis/api_test.clj
+++ b/test/goose/brokers/redis/api_test.clj
@@ -11,7 +11,7 @@
     [goose.brokers.redis.api.enqueued-jobs :as redis-enqueued-jobs]
     [goose.brokers.redis.api.scheduled-jobs :as redis-scheduled-jobs]
     [goose.brokers.redis.commands :as redis-cmds]
-    [goose.brokers.redis.cron :as redis-periodic-jobs]
+    [goose.brokers.redis.cron :as redis-cron]
     [goose.client :as c]
     [goose.defaults :as d]
     [goose.factories :as f]
@@ -194,41 +194,41 @@
       (is (= 3 (count jobs-from-range))))))
 
 (deftest cron-get-all
-  (testing "Should not get any jobs if no periodic job exist"
-    (is (= [] (redis-periodic-jobs/get-all tu/redis-conn))))
-  (testing "Should get all the periodic jobs"
-    (f/create-jobs-in-redis {:periodic 1})
-    (let [jobs (redis-periodic-jobs/get-all tu/redis-conn)]
+  (testing "Should not get any jobs if no cron exist"
+    (is (= [] (redis-cron/get-all tu/redis-conn))))
+  (testing "Should get all the crons"
+    (f/create-jobs-in-redis {:cron 1})
+    (let [jobs (redis-cron/get-all tu/redis-conn)]
       (is (= 1 (count jobs)))
       (is (every? true? (map #(contains? % :cron-name) jobs))))))
 
 (deftest cron-delete
-  (testing "Should delete one periodic job"
-    (f/create-jobs-in-redis {:periodic 1}
-                            {:periodic {:cron-opts {:cron-name "foo-job"}}})
-    (is (= 1 (redis-periodic-jobs/size tu/redis-conn)))
-    (is (true? (redis-periodic-jobs/delete tu/redis-conn "foo-job")))
-    (is (= 0 (redis-periodic-jobs/size tu/redis-conn))))
+  (testing "Should delete one cron job"
+    (f/create-jobs-in-redis {:cron 1}
+                            {:cron {:cron-opts {:cron-name "foo-job"}}})
+    (is (= 1 (redis-cron/size tu/redis-conn)))
+    (is (true? (redis-cron/delete tu/redis-conn "foo-job")))
+    (is (= 0 (redis-cron/size tu/redis-conn))))
   (tu/clear-redis)
-  (testing "Should delete multiple periodic jobs"
-    (f/create-jobs-in-redis {:periodic 1}
-                            {:periodic {:cron-opts {:cron-name "foo-job-1"}}})
-    (f/create-jobs-in-redis {:periodic 1}
-                            {:periodic {:cron-opts {:cron-name "foo-job-2"}}})
-    (f/create-jobs-in-redis {:periodic 1}
-                            {:periodic {:cron-opts {:cron-name "foo-job-3"}}})
-    (is (= 3 (redis-periodic-jobs/size tu/redis-conn)))
-    (is (true? (redis-periodic-jobs/delete tu/redis-conn "foo-job-1" "foo-job-3")))
-    (is (= 1 (redis-periodic-jobs/size tu/redis-conn))))
+  (testing "Should delete multiple cron jobs"
+    (f/create-jobs-in-redis {:cron 1}
+                            {:cron {:cron-opts {:cron-name "foo-job-1"}}})
+    (f/create-jobs-in-redis {:cron 1}
+                            {:cron {:cron-opts {:cron-name "foo-job-2"}}})
+    (f/create-jobs-in-redis {:cron 1}
+                            {:cron {:cron-opts {:cron-name "foo-job-3"}}})
+    (is (= 3 (redis-cron/size tu/redis-conn)))
+    (is (true? (redis-cron/delete tu/redis-conn "foo-job-1" "foo-job-3")))
+    (is (= 1 (redis-cron/size tu/redis-conn))))
   (tu/clear-redis)
-  (testing "Should remove only valid periodic jobs"
-    (f/create-jobs-in-redis {:periodic 1}
-                            {:periodic {:cron-opts {:cron-name "barjob1"}}})
-    (f/create-jobs-in-redis {:periodic 1}
-                            {:periodic {:cron-opts {:cron-name "barjob2"}}})
-    (is (= 2 (redis-periodic-jobs/size tu/redis-conn)))
-    (is (false? (redis-periodic-jobs/delete tu/redis-conn "invalid-cron-name" "barjob2")))
-    (is (= 1 (redis-periodic-jobs/size tu/redis-conn)))))
+  (testing "Should remove only valid cron jobs"
+    (f/create-jobs-in-redis {:cron 1}
+                            {:cron {:cron-opts {:cron-name "barjob1"}}})
+    (f/create-jobs-in-redis {:cron 1}
+                            {:cron {:cron-opts {:cron-name "barjob2"}}})
+    (is (= 2 (redis-cron/size tu/redis-conn)))
+    (is (false? (redis-cron/delete tu/redis-conn "invalid-cron-name" "barjob2")))
+    (is (= 1 (redis-cron/size tu/redis-conn)))))
 
 (deftest dead-jobs-delete-test
   (testing "Should delete a single job and return true"

--- a/test/goose/factories.clj
+++ b/test/goose/factories.clj
@@ -32,7 +32,7 @@
     (scheduler/run-at tu/redis-conn schedule-run-at j)
     (:id j)))
 
-(defn create-periodic-job-in-redis [& [overrides]]
+(defn create-cron-in-redis [& [overrides]]
   (let [job-desc (job-description (:job-description overrides))
         cron-opts (cron-opts (:cron-opts overrides))]
     (cron/register tu/redis-conn cron-opts job-desc)))
@@ -50,13 +50,13 @@
                                    (get-in j [:state :died-at]) j)
     (:id j)))
 
-(defn create-jobs-in-redis [{:keys [enqueued scheduled periodic dead]
-                    :or   {enqueued 0 scheduled 0 periodic 0 dead 0}} & [overrides]]
+(defn create-jobs-in-redis [{:keys [enqueued scheduled cron dead]
+                    :or   {enqueued 0 scheduled 0 cron 0 dead 0}} & [overrides]]
   (let [apply-fn-n-times (fn [n f & args]
                            (dotimes [_ n] (apply f args)))]
     (apply-fn-n-times enqueued create-async-job-in-redis (:enqueued overrides))
     (apply-fn-n-times scheduled create-schedule-job-in-redis (:scheduled overrides))
-    (apply-fn-n-times periodic create-periodic-job-in-redis (:periodic overrides))
+    (apply-fn-n-times cron create-cron-in-redis (:cron overrides))
     (apply-fn-n-times dead create-dead-job-in-redis (:dead overrides))))
 
 ;; Rmq


### PR DESCRIPTION
Periodic jobs are referred to cron as well as periodic jobs in codebase. This PR replaces `periodic-jobs` to `cron` for consistency.

- [ ] Update wiki links for Periodic Job with new Cron Jobs links (before release)