### PR TITLE
Adds out-of-the-box support for SQS message broker

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -10,7 +10,10 @@
            ring/ring-core                        {:mvn/version "1.11.0"}
            hiccup/hiccup                         {:mvn/version "2.0.0-RC2"}
            bidi/bidi                             {:mvn/version "2.1.6"}
-           it.burning/cron-expression-descriptor {:mvn/version "1.2.10"}}
+           it.burning/cron-expression-descriptor {:mvn/version "1.2.10"}
+           com.cognitect.aws/api       {:mvn/version "0.8.710-beta01"}
+           com.cognitect.aws/endpoints {:mvn/version "1.1.12.772"}
+           com.cognitect.aws/sqs       {:mvn/version "869.2.1687.0"}}
  :paths   ["src" "resources/public"]
 
  :aliases {:test       {:extra-paths ["test"]

--- a/src/goose/brokers/sqs/broker.clj
+++ b/src/goose/brokers/sqs/broker.clj
@@ -1,0 +1,74 @@
+(ns goose.brokers.sqs.broker
+  (:require
+   [goose.broker :as b]
+   [goose.brokers.sqs.worker :as sqs-worker]
+   [goose.brokers.sqs.sqs-requests :as sqs-request]
+   [cognitect.aws.client.api :as aws]))
+
+(defprotocol Close
+  "Closes connection to SQS Message Broker."
+  (close [this]))
+
+(defrecord SQS [client queue-url opts]
+  b/Broker
+  ;; SQS supports nothing more than:
+  ;;   - Enqueue a job
+  ;;   - Start a worker process
+  ;;   - Enqueued jobs API
+  ;;   - Batch jobs (Will implement later)
+
+  ;; Enqueue a job for immediate execution
+  (enqueue
+    [_ job]
+    (sqs-request/enqueue client queue-url job))
+
+  ;; Start a worker process
+  (start-worker
+    [_ worker-opts]
+    (sqs-worker/start client queue-url worker-opts))
+
+  ;; Enqueued jobs API
+  (enqueued-jobs-size
+    [_ _]
+    (sqs-request/size client queue-url))
+
+  (enqueued-jobs-purge
+    [_ _]
+    (sqs-request/purge client queue-url))
+
+  Close
+  (close [_]
+    (println "SQS client does not require explicit closure.")))
+
+(def default-opts
+  {:region "ap-south-1"})
+
+(defn new-producer
+  "Creates an SQS broker implementation for producer (client).
+
+  ### Args
+  `opts` : Map of AWS client options.
+
+  ### Usage
+  ```clojure
+  (new-producer {:region \"us-east-1\" :queue-url \"https://sqs.us-east-1.amazonaws.com/123456789012/MyQueue\"})
+  ```"
+  [opts]
+  (let [client    (aws/client {:api :sqs :region (:region opts)})
+        queue-url (:queue-url opts)]
+    (->SQS client queue-url opts)))
+
+(defn new-consumer
+  "Creates an SQS broker implementation for worker (consumer).
+
+  ### Args
+  `opts` : Map of AWS client options.
+
+  ### Usage
+  ```clojure
+  (new-consumer {:region \"us-east-1\" :queue-url \"https://sqs.us-east-1.amazonaws.com/123456789012/MyQueue\"})
+  ```"
+  [opts]
+  (let [client    (aws/client {:api :sqs :region (:region opts)})
+        queue-url (:queue-url opts)]
+    (->SQS client queue-url opts)))

--- a/src/goose/brokers/sqs/broker.clj
+++ b/src/goose/brokers/sqs/broker.clj
@@ -3,13 +3,14 @@
    [goose.broker :as b]
    [goose.brokers.sqs.worker :as sqs-worker]
    [goose.brokers.sqs.sqs-requests :as sqs-request]
-   [cognitect.aws.client.api :as aws]))
+   [cognitect.aws.client.api :as aws]
+   [goose.utils :as u]))
 
 (defprotocol Close
   "Closes connection to SQS Message Broker."
   (close [this]))
 
-(defrecord SQS [client queue-url opts]
+(defrecord SQS [client opts]
   b/Broker
   ;; SQS supports nothing more than:
   ;;   - Enqueue a job
@@ -17,31 +18,42 @@
   ;;   - Enqueued jobs API
   ;;   - Batch jobs (Will implement later)
 
-  ;; Enqueue a job for immediate execution
   (enqueue
-    [_ job]
-    (sqs-request/enqueue client queue-url job))
+    [this job]
+    (let [{:keys [client]} this
+          {:keys [queue-url]} opts]
 
-  ;; Start a worker process
+      (sqs-request/enqueue client queue-url (u/encode-to-str job))))
+
   (start-worker
-    [_ worker-opts]
-    (sqs-worker/start client queue-url worker-opts))
-
-  ;; Enqueued jobs API
-  (enqueued-jobs-size
-    [_ _]
-    (sqs-request/size client queue-url))
-
-  (enqueued-jobs-purge
-    [_ _]
-    (sqs-request/purge client queue-url))
+    [this worker-opts]
+    (let [{:keys [client]} this
+          {:keys [queue-url]} opts]
+      (sqs-worker/start client queue-url worker-opts)))
 
   Close
   (close [_]
     (println "SQS client does not require explicit closure.")))
 
 (def default-opts
-  {:region "ap-south-1"})
+  "Default Config is not allowed like redis or rmq
+   
+   ### Keys
+   `:region`: AWS Region
+   Example: \"ap-south-1\" , \"us-east-1\"
+   
+   `:queue-url`: The Queue URL provided by the AWS SQS
+   Example: \"https://sqs.us-east-1.amazonaws.com/123456789012/MyQueue\""
+  {:region nil
+   :queue-url nil})
+
+(defn- create-sqs
+  "Helper function that creates an SQS broker implementation.
+  It abstracts the common logic for both producer and consumer."
+
+  [opts]
+  (let [client (aws/client {:api :sqs :region (:region opts)})]
+    (->SQS client opts)))
 
 (defn new-producer
   "Creates an SQS broker implementation for producer (client).
@@ -54,9 +66,7 @@
   (new-producer {:region \"us-east-1\" :queue-url \"https://sqs.us-east-1.amazonaws.com/123456789012/MyQueue\"})
   ```"
   [opts]
-  (let [client    (aws/client {:api :sqs :region (:region opts)})
-        queue-url (:queue-url opts)]
-    (->SQS client queue-url opts)))
+  (create-sqs opts))
 
 (defn new-consumer
   "Creates an SQS broker implementation for worker (consumer).
@@ -69,6 +79,4 @@
   (new-consumer {:region \"us-east-1\" :queue-url \"https://sqs.us-east-1.amazonaws.com/123456789012/MyQueue\"})
   ```"
   [opts]
-  (let [client    (aws/client {:api :sqs :region (:region opts)})
-        queue-url (:queue-url opts)]
-    (->SQS client queue-url opts)))
+  (create-sqs opts))

--- a/src/goose/brokers/sqs/sqs_requests.clj
+++ b/src/goose/brokers/sqs/sqs_requests.clj
@@ -1,0 +1,25 @@
+(ns goose.brokers.sqs.sqs-requests
+  (:require
+   [cognitect.aws.client.api :as aws]
+   [clojure.data.json :as json]))
+
+(defn enqueue
+  "Enqueues a job for immediate execution."
+  [client queue-url job]
+  (aws/invoke client {:op      :SendMessage
+                      :request {:QueueUrl     queue-url
+                                :MessageBody  (json/write-str job)
+                                :DelaySeconds 0}}))
+(defn size
+  "Returns the approximate* size of the queue."
+  [client queue-url]
+  (let [attributes (aws/invoke client {:op      :GetQueueAttributes
+                                       :request {:QueueUrl       queue-url
+                                                 :AttributeNames ["ApproximateNumberOfMessages"]}})]
+    (Integer/parseInt (get-in attributes [:Attributes "ApproximateNumberOfMessages"] "0"))))
+
+(defn purge
+  "Purges the queue."
+  [client queue-url]
+  (aws/invoke client {:op      :PurgeQueue
+                      :request {:QueueUrl queue-url}}))

--- a/src/goose/brokers/sqs/sqs_requests.clj
+++ b/src/goose/brokers/sqs/sqs_requests.clj
@@ -10,16 +10,3 @@
                       :request {:QueueUrl     queue-url
                                 :MessageBody  (json/write-str job)
                                 :DelaySeconds 0}}))
-(defn size
-  "Returns the approximate* size of the queue."
-  [client queue-url]
-  (let [attributes (aws/invoke client {:op      :GetQueueAttributes
-                                       :request {:QueueUrl       queue-url
-                                                 :AttributeNames ["ApproximateNumberOfMessages"]}})]
-    (Integer/parseInt (get-in attributes [:Attributes "ApproximateNumberOfMessages"] "0"))))
-
-(defn purge
-  "Purges the queue."
-  [client queue-url]
-  (aws/invoke client {:op      :PurgeQueue
-                      :request {:QueueUrl queue-url}}))

--- a/src/goose/brokers/sqs/worker.clj
+++ b/src/goose/brokers/sqs/worker.clj
@@ -1,0 +1,37 @@
+(ns goose.brokers.sqs.worker
+  (:require
+   [cognitect.aws.client.api :as aws]
+   [clojure.core.async :as async]
+   [goose.utils :as u]
+   [goose.consumer :as c]))
+
+(defn start
+  "Polls messages from an SQS queue, executes each message as a job, and deletes it upon success.
+  
+  Args:
+  `client` : AWS SQS client.
+  `queue-url` : URL of the SQS queue.
+  `opts` : Additional options required for job execution."
+  [client queue-url opts]
+  (let [continue? (atom true)]
+    (async/go-loop []
+      (when @continue?
+        (let [response (aws/invoke client {:op :ReceiveMessage
+                                           :request {:QueueUrl queue-url
+                                                     :MaxNumberOfMessages 1
+                                                     :WaitTimeSeconds 10}})]
+          (when-let [messages (:Messages response)]
+            (doseq [message messages]
+
+              (let [{:keys [Body ReceiptHandle]} message
+                    job (u/decode-from-str Body)]
+                (try
+                  (c/execute-job opts job)
+                  (aws/invoke client {:op :DeleteMessage
+                                      :request {:QueueUrl queue-url
+                                                :ReceiptHandle ReceiptHandle}})
+                  (catch Exception e
+                    (println "Error executing job:" e))))))
+          (recur))))
+    (fn stop-polling []
+      (reset! continue? false))))


### PR DESCRIPTION
Fixes #106 

This is very incomplete now. All we can do now is simple enqueue using perform-async and execute the job.

Remaining things are:

1. Failure handling when executing job
2. Batch job

