### PR TITLE
fix: linter type mismatch - fixes #203

### DIFF
--- a/src/goose/specs.clj
+++ b/src/goose/specs.clj
@@ -95,7 +95,7 @@
 
 ;;; ============== Queue ==============
 (defn- unprefixed? [queue] (not (str/starts-with? queue d/queue-prefix)))
-(defn- not-protected? [queue] (not (str/includes? d/protected-queues queue)))
+(defn- not-protected? [queue] (not (contains? (set d/protected-queues) queue)))
 ;;; RMQ queue names cannot be longer than 255 bytes.
 (s/def ::queue (s/and string? #(< (count %) 200) unprefixed? not-protected?))
 


### PR DESCRIPTION
fixes clj-kondo lint error for type mismatch when using `clojure.string/includes?` on a vector of strs.
instead, a `contains?` over the set is more semantically coherent and does not implicitly rely on clojure's casting mechanisms

refer issue #203 for pre and post  fix clj-kondo lints