### PR TITLE
Fix timing-sensitive broker test flakes

### DIFF
--- a/test/goose/brokers/redis/api_test.clj
+++ b/test/goose/brokers/redis/api_test.clj
@@ -177,14 +177,15 @@
 
 (deftest scheduled-jobs-get-by-range
   (testing "Should get jobs in increasing order of schedule-run-at given a range"
-    (let [future-scheduled-job-id (f/create-schedule-job-in-redis {:schedule-run-at (+ (u/epoch-time-ms)
-                                                                                       100000)})
-          now-scheduled-job-id (f/create-schedule-job-in-redis {:schedule-run-at (+ (u/epoch-time-ms))})
+    (let [base-schedule-run-at (+ (u/epoch-time-ms) 100000)
+          later-scheduled-job-id (f/create-schedule-job-in-redis {:schedule-run-at (+ base-schedule-run-at
+                                                                                      100000)})
+          earlier-scheduled-job-id (f/create-schedule-job-in-redis {:schedule-run-at base-schedule-run-at})
 
-          future-scheduled-job (redis-scheduled-jobs/find-by-id tu/redis-conn future-scheduled-job-id)
-          now-scheduled-job (redis-scheduled-jobs/find-by-id tu/redis-conn now-scheduled-job-id)]
-      (is (true? (>= (get-in future-scheduled-job [:schedule-run-at]) (get-in now-scheduled-job [:schedule-run-at]))))
-      (is (= [now-scheduled-job future-scheduled-job] (redis-scheduled-jobs/get-by-range tu/redis-conn 0 1)))))
+          later-scheduled-job (redis-scheduled-jobs/find-by-id tu/redis-conn later-scheduled-job-id)
+          earlier-scheduled-job (redis-scheduled-jobs/find-by-id tu/redis-conn earlier-scheduled-job-id)]
+      (is (true? (>= (get-in later-scheduled-job [:schedule-run-at]) (get-in earlier-scheduled-job [:schedule-run-at]))))
+      (is (= [earlier-scheduled-job later-scheduled-job] (redis-scheduled-jobs/get-by-range tu/redis-conn 0 1)))))
   (tu/clear-redis)
   (testing "Should get max of (size scheduled-jobs) given higher stop value in range"
     (let [_ (f/create-jobs-in-redis {:scheduled 3})

--- a/test/goose/brokers/rmq/integration_test.clj
+++ b/test/goose/brokers/rmq/integration_test.clj
@@ -9,7 +9,8 @@
    [goose.test-utils :as tu]
    [goose.worker :as w]
 
-   [clojure.test :refer [deftest is testing use-fixtures]])
+   [clojure.test :refer [deftest is testing use-fixtures]]
+   [langohr.confirm :as lcnf])
   (:import
    (clojure.lang ExceptionInfo)
    [java.util UUID]
@@ -107,21 +108,23 @@
   (deliver @ack-delivery-tag tag))
 (defn test-nack-handler [_ _ _])
 (deftest publisher-confirm-test
-  ;; This test fails quite rarely.
-  ;; RMQ confirms in 1ms too sometimes ¯\_(ツ)_/¯
-  ;; Remove this test if it happens often.
   (testing "[rmq][sync-confirms] Publish timed out"
     (let [opts (assoc tu/rmq-opts
-                      :publisher-confirms {:strategy d/sync-confirms :timeout-ms 1})
+                      :publisher-confirms {:strategy d/sync-confirms
+                                           :timeout-ms 1000})
           producer (rmq/new-producer opts 1)
           client-opts {:queue      "sync-publisher-confirms-test"
                        :retry-opts retry/default-opts
                        :broker     producer}]
-      (is
-       (thrown?
-        TimeoutException
-        (c/perform-async client-opts `tu/my-fn)))
-      (rmq/close producer)))
+      (try
+        (with-redefs [lcnf/wait-for-confirms (fn [_ ^long _]
+                                               (throw (TimeoutException.)))]
+          (is
+           (thrown?
+            TimeoutException
+            (c/perform-async client-opts `tu/my-fn))))
+        (finally
+          (rmq/close producer)))))
 
   (testing "[rmq][async-confirms] Ack handler called"
     (reset! ack-channel-number (promise))


### PR DESCRIPTION
## Summary

Fixes the timing-sensitive broker test flakes tracked under #215.

### RabbitMQ publisher confirms

The old test configured sync publisher confirms with `:timeout-ms 1` and expected RabbitMQ to be slow enough to throw `TimeoutException`. RabbitMQ can legitimately confirm within 1ms, which made the test fail intermittently with `actual: nil`.

This replaces the wall-clock race with a deterministic timeout path by redefining `langohr.confirm/wait-for-confirms` to throw `TimeoutException` for this assertion.

### Redis scheduled jobs range ordering

The old `scheduled-jobs-get-by-range` test created one job at `(u/epoch-time-ms)`. `scheduler/run-at` compares that value against a fresh current time and moves past jobs directly to the ready queue, so the job could disappear from the scheduled sorted set if the clock advanced by 1ms.

This now uses two future timestamps for the ordering assertion, keeping both jobs in the scheduled sorted set deterministically.

## Validation

- `clj-kondo --lint test/goose/brokers/redis/api_test.clj test/goose/brokers/rmq/integration_test.clj --fail-level error`
- `clj -X:test :nses '[goose.brokers.redis.api-test goose.brokers.rmq.integration-test]'`
